### PR TITLE
[Feat] 고민작성지 뷰(템플릿 상세보기뷰) ViewModel 구현

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
@@ -9,10 +9,11 @@ import UIKit
 import Foundation
 
 /// 서버통신용 모델
-struct TemplateListModel {
+struct TemplateListModel: Codable {
     let templateId: Int
     let templateTitle: String
-    let templateDetail: String
+    let shortInfo: String
+    let info: String
     let hasUsed: Bool
 }
 
@@ -21,5 +22,13 @@ struct TemplateListPublisherModel {
     let templateId: Int
     let templateTitle: String
     let templateDetail: String
+    let image: UIImage
+}
+
+/// View에 뿌려주기 위한 model
+struct TemplateInfoPublisherModel {
+    let templateId: Int
+    let templateTitle: String
+    let info: String
     let image: UIImage
 }

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
@@ -9,11 +9,10 @@ import UIKit
 import Foundation
 
 /// 서버통신용 모델
-struct TemplateListModel: Codable {
+struct TemplateListModel {
     let templateId: Int
     let templateTitle: String
-    let shortInfo: String
-    let info: String
+    let templateDetail: String
     let hasUsed: Bool
 }
 
@@ -22,13 +21,5 @@ struct TemplateListPublisherModel {
     let templateId: Int
     let templateTitle: String
     let templateDetail: String
-    let image: UIImage
-}
-
-/// View에 뿌려주기 위한 model
-struct TemplateInfoPublisherModel {
-    let templateId: Int
-    let templateTitle: String
-    let info: String
     let image: UIImage
 }

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
@@ -13,6 +13,7 @@ struct TemplateListModel {
     let templateId: Int
     let templateTitle: String
     let templateDetail: String
+    let info: String
     let hasUsed: Bool
 }
 
@@ -21,5 +22,13 @@ struct TemplateListPublisherModel {
     let templateId: Int
     let templateTitle: String
     let templateDetail: String
+    let image: UIImage
+}
+
+/// View에 뿌려주기 위한 model
+struct TemplateInfoPublisherModel {
+    let templateId: Int
+    let templateTitle: String
+    let info: String
     let image: UIImage
 }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
@@ -88,7 +88,7 @@ extension ArchiveModalVC{
 extension ArchiveModalVC{
     
     /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
-    private func setBindings() {
+    fileprivate func setBindings() {
         print("ViewController - setBindings()")
         self.templateVM.templateListPublisher.sink{ [weak self] (updatedList : [TemplateListPublisherModel]) in
             print("ViewController - updatedList.count: \(updatedList.count)")

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
@@ -88,7 +88,7 @@ extension ArchiveModalVC{
 extension ArchiveModalVC{
     
     /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
-    fileprivate func setBindings() {
+    private func setBindings() {
         print("ViewController - setBindings()")
         self.templateVM.templateListPublisher.sink{ [weak self] (updatedList : [TemplateListPublisherModel]) in
             print("ViewController - updatedList.count: \(updatedList.count)")

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
@@ -207,12 +207,3 @@ extension TemplateInfoTVC {
         }
     }
 }
-
-extension TemplateInfoTVC {
-    // MARK: - DataBind
-    func dataBind(model: TemplateInfoPublisherModel, indexPath: IndexPath) {
-        jewelImage.image = model.image
-        titleLabel.text = model.templateTitle
-        templateDetail.text = model.info
-    }
-}

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
@@ -206,4 +206,10 @@ extension TemplateInfoTVC {
             $0.height.equalTo(26.adjustedW)
         }
     }
+    
+    func dataBind(model: TemplateInfoPublisherModel) {
+        jewelImage.image = model.image
+        titleLabel.text = model.templateTitle
+        templateDetail.text = model.info
+    }
 }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
@@ -207,3 +207,12 @@ extension TemplateInfoTVC {
         }
     }
 }
+
+extension TemplateInfoTVC {
+    // MARK: - DataBind
+    func dataBind(model: TemplateInfoPublisherModel, indexPath: IndexPath) {
+        jewelImage.image = model.image
+        titleLabel.text = model.templateTitle
+        templateDetail.text = model.info
+    }
+}

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -38,6 +38,13 @@ class TemplateInfoVC: UIViewController {
     
     var expandedCells = [Bool]()
     
+    // MARK: - ViewModel
+    private var templateVM: TemplateViewModel = TemplateViewModel()
+    
+    private var templateInfoList: [TemplateInfoPublisherModel] = []
+    private var disposalbleBag = Set<AnyCancellable>()
+
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
@@ -45,6 +52,7 @@ class TemplateInfoVC: UIViewController {
         registerTV()
         resetCellStatus()
         setObserver()
+        setBindings()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -146,7 +154,7 @@ extension TemplateInfoVC: UITableViewDelegate {
 extension TemplateInfoVC : UITableViewDataSource
 {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 6
+        return templateInfoList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -157,6 +165,22 @@ extension TemplateInfoVC : UITableViewDataSource
         /// 각 cell 클릭 시 해당하는 cell의 indexPath를 TVC의 indexPath로 전달
         cell.indexPath = indexPath
         
+        /// 서버로부터 받아온 데이터를 viewModel을 통해 넣어준다.
+        cell.dataBind(model: templateInfoList[indexPath.item], indexPath: indexPath)
+        
         return cell
     }
 }
+
+// MARK: - 뷰모델 관련
+extension TemplateInfoVC{
+    /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
+    private func setBindings() {
+        print("ViewController - setBindings()")
+        self.templateVM.templateInfoPublisher.sink{ [weak self] (updatedList : [TemplateInfoPublisherModel]) in
+            print("ViewController - updatedList.count: \(updatedList.count)")
+            self?.templateInfoList = updatedList
+        }.store(in: &disposalbleBag)
+    }
+}
+

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -38,13 +38,6 @@ class TemplateInfoVC: UIViewController {
     
     var expandedCells = [Bool]()
     
-    // MARK: - ViewModel
-    private var templateVM: TemplateViewModel = TemplateViewModel()
-    
-    private var templateInfoList: [TemplateInfoPublisherModel] = []
-    private var disposalbleBag = Set<AnyCancellable>()
-
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
@@ -52,7 +45,6 @@ class TemplateInfoVC: UIViewController {
         registerTV()
         resetCellStatus()
         setObserver()
-        setBindings()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -154,7 +146,7 @@ extension TemplateInfoVC: UITableViewDelegate {
 extension TemplateInfoVC : UITableViewDataSource
 {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return templateInfoList.count
+        return 6
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -165,22 +157,6 @@ extension TemplateInfoVC : UITableViewDataSource
         /// 각 cell 클릭 시 해당하는 cell의 indexPath를 TVC의 indexPath로 전달
         cell.indexPath = indexPath
         
-        /// 서버로부터 받아온 데이터를 viewModel을 통해 넣어준다.
-        cell.dataBind(model: templateInfoList[indexPath.item], indexPath: indexPath)
-        
         return cell
     }
 }
-
-// MARK: - 뷰모델 관련
-extension TemplateInfoVC{
-    /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
-    private func setBindings() {
-        print("ViewController - setBindings()")
-        self.templateVM.templateInfoPublisher.sink{ [weak self] (updatedList : [TemplateInfoPublisherModel]) in
-            print("ViewController - updatedList.count: \(updatedList.count)")
-            self?.templateInfoList = updatedList
-        }.store(in: &disposalbleBag)
-    }
-}
-

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -32,53 +32,40 @@ class TemplateViewModel {
     ]
     
     var templateListDummy = [
-        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", shortInfo: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "", hasUsed: true),
-        TemplateListModel(templateId: 1, templateTitle: "Free Flow", shortInfo: "빈 공간을 자유롭게 채우기", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
-        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", shortInfo: "할까? 말까? 최고의 선택을 돕는 해결사", info: "문제의 근본적인 이유를 찾아주는 5why 기법이에요. 왜?, 그래서 왜?, 그리고 왜? 숨어있는 원인을 캐내 문제를 해결할 수 있어요", hasUsed: true),
-        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", shortInfo: "5why 기법을 활용한 물음표 곱씹기", info: "무언가 걱정되는 일이 있으신가요? 데일카네기가 제시한 글쓰기 가이드라인에 맞춰 무엇이 고민인지 쓰고, 이를 해결하기 위한 방법을 논리적으로 찾으며 차분히 생각해봅시다", hasUsed: true),
-        TemplateListModel(templateId: 4, templateTitle: "자기관리론", shortInfo: "데일카네기가 제시한 걱정 극복 글쓰기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", shortInfo: "One thing, 우선순위 정하기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", shortInfo: "긍정적인 힘을 만드는 감사 일기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 7, templateTitle: "10-10-10", shortInfo: "수지 웰치의 좋은 결정을 내리는 간단한 방법", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", shortInfo: "move! move! 일단 움직여, 실행론", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false)
+        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", hasUsed: true),
+        TemplateListModel(templateId: 1, templateTitle: "Free Flow", templateDetail: "빈 공간을 자유롭게 채우기", hasUsed: true),
+        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", templateDetail: "할까? 말까? 최고의 선택을 돕는 해결사", hasUsed: true),
+        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", templateDetail: "5why 기법을 활용한 물음표 곱씹기", hasUsed: true),
+        TemplateListModel(templateId: 4, templateTitle: "자기관리론", templateDetail: "데일카네기가 제시한 걱정 극복 글쓰기", hasUsed: false),
+        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", templateDetail: "One thing, 우선순위 정하기", hasUsed: false),
+        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", templateDetail: "긍정적인 힘을 만드는 감사 일기", hasUsed: false),
+        TemplateListModel(templateId: 7, templateTitle: "10-10-10", templateDetail: "수지 웰치의 좋은 결정을 내리는 간단한 방법", hasUsed: false),
+        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", templateDetail: "move! move! 일단 움직여, 실행론", hasUsed: false)
     ]
     
     var templateUpdateList: [TemplateListPublisherModel] = []
     
     lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
     
-    /// 고민 작성지에 들어갈 내용을 담을 currentValueSubject 생성
-    var templateInfoList: [TemplateInfoPublisherModel] = []
-    
-    lazy var templateInfoPublisher = CurrentValueSubject<[TemplateInfoPublisherModel], Never>(templateInfoList)
-    
     init() {
         templateUpdateList = []
-        templateInfoList = []
-        convertListIdtoImg()
-        convertInfoIdtoImg()
+        convertIdtoImg()
     }
 }
 
 // MARK: - Functions
 extension TemplateViewModel {
-    private func convertListIdtoImg() {
+    private func convertIdtoImg() {
         templateListDummy.forEach {
             if $0.hasUsed == true {
                 guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
+                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
             }
             else {
                 guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: false)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
+                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
             }
-        }
-    }
-    
-    private func convertInfoIdtoImg() {
-        templateListDummy.forEach {
-                guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-            templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
+            
         }
     }
 }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -32,40 +32,53 @@ class TemplateViewModel {
     ]
     
     var templateListDummy = [
-        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", hasUsed: true),
-        TemplateListModel(templateId: 1, templateTitle: "Free Flow", templateDetail: "빈 공간을 자유롭게 채우기", hasUsed: true),
-        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", templateDetail: "할까? 말까? 최고의 선택을 돕는 해결사", hasUsed: true),
-        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", templateDetail: "5why 기법을 활용한 물음표 곱씹기", hasUsed: true),
-        TemplateListModel(templateId: 4, templateTitle: "자기관리론", templateDetail: "데일카네기가 제시한 걱정 극복 글쓰기", hasUsed: false),
-        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", templateDetail: "One thing, 우선순위 정하기", hasUsed: false),
-        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", templateDetail: "긍정적인 힘을 만드는 감사 일기", hasUsed: false),
-        TemplateListModel(templateId: 7, templateTitle: "10-10-10", templateDetail: "수지 웰치의 좋은 결정을 내리는 간단한 방법", hasUsed: false),
-        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", templateDetail: "move! move! 일단 움직여, 실행론", hasUsed: false)
+        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", shortInfo: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "", hasUsed: true),
+        TemplateListModel(templateId: 1, templateTitle: "Free Flow", shortInfo: "빈 공간을 자유롭게 채우기", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
+        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", shortInfo: "할까? 말까? 최고의 선택을 돕는 해결사", info: "문제의 근본적인 이유를 찾아주는 5why 기법이에요. 왜?, 그래서 왜?, 그리고 왜? 숨어있는 원인을 캐내 문제를 해결할 수 있어요", hasUsed: true),
+        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", shortInfo: "5why 기법을 활용한 물음표 곱씹기", info: "무언가 걱정되는 일이 있으신가요? 데일카네기가 제시한 글쓰기 가이드라인에 맞춰 무엇이 고민인지 쓰고, 이를 해결하기 위한 방법을 논리적으로 찾으며 차분히 생각해봅시다", hasUsed: true),
+        TemplateListModel(templateId: 4, templateTitle: "자기관리론", shortInfo: "데일카네기가 제시한 걱정 극복 글쓰기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", shortInfo: "One thing, 우선순위 정하기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", shortInfo: "긍정적인 힘을 만드는 감사 일기", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 7, templateTitle: "10-10-10", shortInfo: "수지 웰치의 좋은 결정을 내리는 간단한 방법", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", shortInfo: "move! move! 일단 움직여, 실행론", info: "집중해야 할 단 한 가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false)
     ]
     
     var templateUpdateList: [TemplateListPublisherModel] = []
     
     lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
     
+    /// 고민 작성지에 들어갈 내용을 담을 currentValueSubject 생성
+    var templateInfoList: [TemplateInfoPublisherModel] = []
+    
+    lazy var templateInfoPublisher = CurrentValueSubject<[TemplateInfoPublisherModel], Never>(templateInfoList)
+    
     init() {
         templateUpdateList = []
-        convertIdtoImg()
+        templateInfoList = []
+        convertListIdtoImg()
+        convertInfoIdtoImg()
     }
 }
 
 // MARK: - Functions
 extension TemplateViewModel {
-    private func convertIdtoImg() {
+    private func convertListIdtoImg() {
         templateListDummy.forEach {
             if $0.hasUsed == true {
                 guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
+                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
             }
             else {
                 guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: false)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
+                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
             }
-            
+        }
+    }
+    
+    private func convertInfoIdtoImg() {
+        templateListDummy.forEach {
+                guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
+            templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
         }
     }
 }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -8,7 +8,8 @@
 import UIKit
 import Combine
 
-class TemplateViewModel {
+// template Modal용
+class TemplateViewModel: ViewModelType {
     
     struct customKey: Hashable {
         let index: Int
@@ -32,20 +33,38 @@ class TemplateViewModel {
     ]
     
     var templateListDummy = [
-        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", hasUsed: true),
-        TemplateListModel(templateId: 1, templateTitle: "Free Flow", templateDetail: "빈 공간을 자유롭게 채우기", hasUsed: true),
-        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", templateDetail: "할까? 말까? 최고의 선택을 돕는 해결사", hasUsed: true),
-        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", templateDetail: "5why 기법을 활용한 물음표 곱씹기", hasUsed: true),
-        TemplateListModel(templateId: 4, templateTitle: "자기관리론", templateDetail: "데일카네기가 제시한 걱정 극복 글쓰기", hasUsed: false),
-        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", templateDetail: "One thing, 우선순위 정하기", hasUsed: false),
-        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", templateDetail: "긍정적인 힘을 만드는 감사 일기", hasUsed: false),
-        TemplateListModel(templateId: 7, templateTitle: "10-10-10", templateDetail: "수지 웰치의 좋은 결정을 내리는 간단한 방법", hasUsed: false),
-        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", templateDetail: "move! move! 일단 움직여, 실행론", hasUsed: false)
+        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
+        TemplateListModel(templateId: 1, templateTitle: "Free Flow", templateDetail: "빈 공간을 자유롭게 채우기", info: "내가 할 수 있는 선택지를 나열해보세요. 각각 어떤 장점과 단점을 가지고 있나요? 당신의 가능성을 펼쳐 비교해 더 나은 선택을 할 수 있도록 도와줄게요.", hasUsed: true),
+        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", templateDetail: "할까? 말까? 최고의 선택을 돕는 해결사", info: "문제의 근본적인 이유를 찾아주는 3why 기법이에요. 왜?, 그래서 왜?, 그리고 왜? 숨어있는 원인을 캐내 문제를 해결할 수 있어요.", hasUsed: true),
+        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", templateDetail: "5why 기법을 활용한 물음표 곱씹기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: true),
+        TemplateListModel(templateId: 4, templateTitle: "자기관리론", templateDetail: "데일카네기가 제시한 걱정 극복 글쓰기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", templateDetail: "One thing, 우선순위 정하기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", templateDetail: "긍정적인 힘을 만드는 감사 일기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 7, templateTitle: "10-10-10", templateDetail: "수지 웰치의 좋은 결정을 내리는 간단한 방법", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
+        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", templateDetail: "move! move! 일단 움직여, 실행론", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false)
     ]
     
     var templateUpdateList: [TemplateListPublisherModel] = []
     
     lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
+    
+    // templateinfo
+    private var templateInfoList: [TemplateInfoPublisherModel] = []
+    private var cancellables = Set<AnyCancellable>()
+    
+    typealias Input = AnyPublisher<Void, Never>
+    
+    typealias Output = AnyPublisher<[TemplateInfoPublisherModel], Never>
+    
+    private let output = PassthroughSubject<[TemplateInfoPublisherModel], Never> ()
+
+    func transform(input: Input) -> AnyPublisher<[TemplateInfoPublisherModel], Never> {
+        input.sink{[weak self] _ in
+            self?.convertTemplateInfo()
+        }
+        .store(in: &cancellables)
+        return output.eraseToAnyPublisher()
+    }
     
     init() {
         templateUpdateList = []
@@ -57,15 +76,17 @@ class TemplateViewModel {
 extension TemplateViewModel {
     private func convertIdtoImg() {
         templateListDummy.forEach {
-            if $0.hasUsed == true {
-                guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
-            }
-            else {
-                guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: false)] else { return }
-                templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
-            }
-            
+            guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return }
+            templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
         }
     }
+    private func convertTemplateInfo() {
+        templateInfoList = []
+        templateListDummy.forEach {
+            guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
+            self.templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
+        }
+        self.output.send(templateInfoList)
+    }
 }
+


### PR DESCRIPTION
## 💪 작업한 내용
- ArchiveModalVC, TemplateModalVC와 동일한 TemplateInfoViewModel을 사용하여 구현하였기 때문에 코드의 통일성을 위해 CurrentValueSubject를 사용해주었습니다. 
- 서버통신용 모델과 ViewController에 뿌려주기 위한 모델을 각각 만든 뒤, 고민 작성지 뷰의 TableView와 TemplateInfoViewModel을 sink 및 databind하여 화면에 데이터들이 보여지게끔 구현했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 템플릿 선택하는 Modal 뷰와 동일하게 구현하였습니다!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-07-28 at 01 30 04](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/1b057898-b5e1-4acf-9c04-09f36bcec8b2)

## 🚨 관련 이슈
- Resolved: #23 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
