### PR TITLE
[Feat] 고민 캐기 창 및 캐기완료 메시지 창 구현

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		E73CA3E42A6AB09100BAC9D6 /* HomeWorryDetailTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3E32A6AB09100BAC9D6 /* HomeWorryDetailTVC.swift */; };
 		E73CA3E72A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3E62A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift */; };
 		E74968D62A74B84100C3C0CF /* WorryDetailReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */; };
+		E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */; };
 		E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */; };
 		E79AAC212A52F19300F3F439 /* ToastMessageColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */; };
 		E79AAC302A52F2C300F3F439 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC222A52F2C200F3F439 /* String+.swift */; };
@@ -105,6 +106,7 @@
 		E73CA3E32A6AB09100BAC9D6 /* HomeWorryDetailTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailTVC.swift; sourceTree = "<group>"; };
 		E73CA3E62A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailHeaderView.swift; sourceTree = "<group>"; };
 		E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDetailReviewView.swift; sourceTree = "<group>"; };
+		E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDecisionVC.swift; sourceTree = "<group>"; };
 		E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastMessageColorType.swift; sourceTree = "<group>"; };
 		E79AAC222A52F2C200F3F439 /* String+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				E73CA3E62A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift */,
 				E7FEC0952A6CFD12006F36BF /* HomeWorryDetailFooterView.swift */,
 				E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */,
+				E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */,
 			);
 			path = HomeWorryDetail;
 			sourceTree = "<group>";
@@ -621,6 +624,7 @@
 				E73CA3E22A6A688A00BAC9D6 /* CustomNavigationBarView.swift in Sources */,
 				85887D972A60430600F7FB21 /* ArchiveModalCVC.swift in Sources */,
 				E79AAC372A52F2C300F3F439 /* CALayer+.swift in Sources */,
+				E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */,
 				E79AAC3D2A52F2C300F3F439 /* UIFont+.swift in Sources */,
 				85887D8E2A5D086300F7FB21 /* TemplateViewModel.swift in Sources */,
 				E7BB4F492A5EF7320018312B /* HomeGemListModel.swift in Sources */,

--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		E73CA3E72A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3E62A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift */; };
 		E74968D62A74B84100C3C0CF /* WorryDetailReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */; };
 		E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */; };
+		E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */; };
 		E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */; };
 		E79AAC212A52F19300F3F439 /* ToastMessageColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */; };
 		E79AAC302A52F2C300F3F439 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC222A52F2C200F3F439 /* String+.swift */; };
@@ -107,6 +108,7 @@
 		E73CA3E62A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailHeaderView.swift; sourceTree = "<group>"; };
 		E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDetailReviewView.swift; sourceTree = "<group>"; };
 		E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDecisionVC.swift; sourceTree = "<group>"; };
+		E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryQuoteView.swift; sourceTree = "<group>"; };
 		E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastMessageColorType.swift; sourceTree = "<group>"; };
 		E79AAC222A52F2C200F3F439 /* String+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				E7FEC0952A6CFD12006F36BF /* HomeWorryDetailFooterView.swift */,
 				E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */,
 				E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */,
+				E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */,
 			);
 			path = HomeWorryDetail;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				E79AAC382A52F2C300F3F439 /* UIStackView+.swift in Sources */,
 				E7C808EB2A4D37F800F475CE /* SceneDelegate.swift in Sources */,
 				85887D822A5C429F00F7FB21 /* WriteModalVC.swift in Sources */,
+				E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */,
 				E79AAC352A52F2C300F3F439 /* UIImageView+.swift in Sources */,
 				85887D9C2A605D0B00F7FB21 /* TemplateInfoVC.swift in Sources */,
 				E7BB4F4F2A5EF81C0018312B /* WorryListViewModel.swift in Sources */,

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -93,6 +93,7 @@ final class HomeWorryDetailVC: BaseVC {
         setReviewTextView()
         dataBind()
         hideKeyboardWhenTappedAround()
+        setPressAction()
     }
     override func viewWillLayoutSubviews() {
         /// 테이블 뷰 contentSize.height 보다 1이상 커야지 footer뷰가 제대로 나옴
@@ -211,6 +212,15 @@ final class HomeWorryDetailVC: BaseVC {
     
     private func setReviewTextView() {
         reviewView.reviewTextView.delegate = self
+    }
+    
+    private func setPressAction() {
+        digWorryButton.press {
+            let vc = WorryDecisionVC()
+            vc.modalPresentationStyle = .overCurrentContext
+            vc.modalTransitionStyle = .coverVertical
+            self.present(vc, animated: true, completion: nil)
+        }
     }
     
     private func dataBind() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -217,6 +217,7 @@ final class HomeWorryDetailVC: BaseVC {
     private func setPressAction() {
         digWorryButton.press {
             let vc = WorryDecisionVC()
+            vc.setTemplateId(id: self.templateId)
             vc.modalPresentationStyle = .overCurrentContext
             vc.modalTransitionStyle = .coverVertical
             self.present(vc, animated: true, completion: nil)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -51,6 +51,11 @@ final class WorryDecisionVC: BaseVC {
         $0.titleLabel?.textAlignment = .center
         $0.layer.cornerRadius = 8
     }
+    
+    private let topInset: CGFloat = 303
+    private var hasKeyboard: Bool = false
+    private let placeholderText = "40자 이내로 적어주세요."
+    
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,18 +64,92 @@ final class WorryDecisionVC: BaseVC {
         hideKeyboardWhenTappedAround()
         setTextView()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.addKeyboardObserver()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.removeKeyboardObserver()
+    }
+    
+    // MARK: - Function
+    private func setTextView() {
+        worryTextView.delegate = self
     }
     
 
-    /*
-    // MARK: - Navigation
+}
+// MARK: - Keyboard Setting
+extension WorryDecisionVC {
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.keyboardWillAppear(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(keyboardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
     }
-    */
+    
+    
+    private func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillShowNotification,
+            object: nibName
+        )
+        
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nibName
+        )
+    }
+    
+    @objc
+    func keyboardWillAppear(_ notification: NSNotification) {
+        hasKeyboard = true
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                UIView.animate(withDuration: 0.1, animations: { [self] in
+                    let newInset = abs(topInset - (keyboardSize.height - 100))
+                    mainView.snp.updateConstraints {
+                        $0.top.equalTo(view.safeAreaLayoutGuide).inset(newInset.adjustedH)
+                    }
+                })
+        }
+    }
+    @objc
+    func keyboardWillDisappear(_ notification: NSNotification) {
+        UIView.animate(withDuration: 0.1, animations: { [self] in
+            mainView.snp.updateConstraints {
+                $0.top.equalTo(view.safeAreaLayoutGuide).inset(topInset.adjustedH)
+            }
+        })
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        guard let touch = touches.first else {
+            return
+        }
+        
+        /// 배경 영역을 탭한 경우 뷰 컨트롤러를 닫음
+        if !mainView.frame.contains(touch.location(in: view)) && !hasKeyboard {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.dismiss(animated: true, completion: nil)
+            })
+        }
+        
+        ///  키보드가 내려가 있었을 때와 키보드가 올라왔있다가 내려가고 호출되어 false 고정
+        hasKeyboard = false
+    }
+}
 
 // MARK: - UI
 extension WorryDecisionVC {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -32,14 +32,14 @@ final class WorryDecisionVC: BaseVC {
         $0.textColor = .kGray5
     }
     
-    private lazy var worryTextView = UITextView().then {
+    private let worryTextView = UITextView().then {
         $0.backgroundColor = .kGray4
         $0.layer.cornerRadius = 8
         $0.text = "40자 이내로 적어주세요."
         $0.font = .kB4R14
         $0.textColor = .kGray3
-        $0.isScrollEnabled = false
-        $0.textContainerInset = UIEdgeInsets(top: 12, left: 5, bottom: 0, right: 0)
+        $0.isScrollEnabled = true
+        $0.textContainerInset = UIEdgeInsets(top: 12, left: 5, bottom: 12, right: 5)
     }
     
     private let doneButton = UIButton().then {
@@ -54,9 +54,8 @@ final class WorryDecisionVC: BaseVC {
     private let topInset: CGFloat = 303.adjustedH
     private var hasKeyboard: Bool = false
     private let placeholderText = "40자 이내로 적어주세요."
-    /// TextView의 content 기본 높이 27을 뺀 뷰의 높이
-    private var defaultTextHeight: CGFloat = 27.7
-    private lazy var defaultTextViewHeight: CGFloat = (40 - defaultTextHeight).adjustedH
+
+    private var defaultTextHeight: CGFloat = 40
     private lazy var defaultMainViewHeight: CGFloat = (282 - defaultTextHeight).adjustedH
     
     // MARK: - View Life Cycle
@@ -169,6 +168,7 @@ extension WorryDecisionVC: UITextViewDelegate {
         /// 행간 간격 150% 설정
         let style = NSMutableParagraphStyle()
         style.lineSpacing = UIFont.kB4R14.lineHeight * 0.5
+        style.alignment = .justified
         let attributedText = NSAttributedString(
             string: inputText,
             attributes: [
@@ -179,10 +179,6 @@ extension WorryDecisionVC: UITextViewDelegate {
         )
         
         textView.attributedText = attributedText
-        
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        print("일",newSize.height)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -193,10 +189,6 @@ extension WorryDecisionVC: UITextViewDelegate {
             textView.font = .kB4R14
             textView.textColor = .kGray3
         }
-        
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        print("이",newSize.height)
     }
     
     func textViewDidChange(_ textView: UITextView) {
@@ -206,17 +198,16 @@ extension WorryDecisionVC: UITextViewDelegate {
         if textView.text.count > 40 {
             textView.deleteBackward()
         }
-       
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        worryTextView.snp.updateConstraints {
-            $0.height.equalTo(newSize.height + defaultTextViewHeight)
-        }
+        if textView.contentSize.height < defaultTextHeight * 2 - textView.textContainerInset.top {
+            
+            worryTextView.snp.updateConstraints {
+                $0.height.equalTo(textView.contentSize.height)
+            }
 
-        mainView.snp.updateConstraints {
-            $0.height.equalTo(newSize.height + defaultMainViewHeight)
+            mainView.snp.updateConstraints {
+                $0.height.equalTo(textView.contentSize.height + defaultMainViewHeight)
+            }
         }
-        print("삼", newSize.height)
     }
 }
 
@@ -252,7 +243,7 @@ extension WorryDecisionVC {
         worryTextView.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalToSuperview().inset(18)
             $0.top.equalTo(subTitle.snp.bottom).offset(16)
-            $0.height.equalTo(defaultTextViewHeight + defaultTextHeight)
+            $0.height.equalTo(defaultTextHeight)
         }
         
         doneButton.snp.makeConstraints {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -6,13 +6,59 @@
 //
 
 import UIKit
+import SnapKit
+import Then
 
-class WorryDecisionVC: UIViewController {
-
+final class WorryDecisionVC: BaseVC {
+    
+    private let mainView = UIView().then {
+        $0.backgroundColor = .kGray3
+        $0.layer.cornerRadius = 20
+    }
+    
+    private let pickaxeImageView = UIImageView().then {
+        $0.image = UIImage(named: "Pickaxe")
+    }
+    
+    private let mainTitle = UILabel().then {
+        $0.text = "이 고민, 어떻게 캐낼까요?"
+        $0.font = .kB1B16
+        $0.textColor = .kWhite
+    }
+    
+    private let subTitle = UILabel().then {
+        $0.text = "고민 끝에 결정한 나의 생각을 적어주세요!"
+        $0.font = .kSb1R12
+        $0.textColor = .kGray5
+    }
+    
+    private lazy var worryTextView = UITextView().then {
+        $0.backgroundColor = .kGray4
+        $0.layer.cornerRadius = 8
+        $0.text = "40자 이내로 적어주세요."
+        $0.font = .kB4R14
+        $0.textColor = .kGray3
+        $0.isScrollEnabled = false
+        
+        $0.textContainerInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
+    }
+    
+    private let doneButton = UIButton().then {
+        $0.backgroundColor = .kYellow1
+        $0.setTitle("완료", for: .normal)
+        $0.titleLabel?.textColor = .kWhite
+        $0.titleLabel?.font = .kB1B16
+        $0.titleLabel?.textAlignment = .center
+        $0.layer.cornerRadius = 8
+    }
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        view.backgroundColor = UIColor(white: 0, alpha: 0.5)
+        setLayout()
+        hideKeyboardWhenTappedAround()
+        setTextView()
+    }
     }
     
 
@@ -26,4 +72,46 @@ class WorryDecisionVC: UIViewController {
     }
     */
 
+// MARK: - UI
+extension WorryDecisionVC {
+    private func setLayout() {
+        self.view.addSubview(mainView)
+        
+        mainView.addSubviews([pickaxeImageView, mainTitle, subTitle, worryTextView, doneButton])
+        
+        mainView.snp.makeConstraints {
+            $0.directionalHorizontalEdges.equalToSuperview().inset(19)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(topInset.adjustedH)
+            $0.height.equalTo(282.adjustedH)
+        }
+        
+        pickaxeImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().inset(20)
+            $0.height.width.equalTo(54)
+        }
+        
+        mainTitle.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(pickaxeImageView.snp.bottom).offset(21)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(mainTitle.snp.bottom).offset(12)
+        }
+        
+        worryTextView.snp.makeConstraints {
+            $0.directionalHorizontalEdges.equalToSuperview().inset(18)
+            $0.top.equalTo(subTitle.snp.bottom).offset(16)
+            $0.height.equalTo(40)
+        }
+        
+        doneButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(38)
+            $0.height.equalTo(30)
+            $0.width.equalTo(78)
+        }
+    }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -12,7 +12,7 @@ import Then
 final class WorryDecisionVC: BaseVC {
     
     private let mainView = UIView().then {
-        $0.backgroundColor = .kGray3
+        $0.backgroundColor = .kGray2
         $0.layer.cornerRadius = 20
     }
     
@@ -50,13 +50,20 @@ final class WorryDecisionVC: BaseVC {
         $0.titleLabel?.textAlignment = .center
         $0.layer.cornerRadius = 8
     }
-    
+    private let quoteView = WorryQuoteView().then {
+        $0.backgroundColor = .kGray2
+        $0.layer.cornerRadius = 20
+        $0.alpha = 0.0
+    }
+
     private let topInset: CGFloat = 303.adjustedH
     private var hasKeyboard: Bool = false
     private let placeholderText = "40자 이내로 적어주세요."
 
     private var defaultTextHeight: CGFloat = 40
     private lazy var defaultMainViewHeight: CGFloat = (282 - defaultTextHeight).adjustedH
+    
+    private var templateId: Int = 0
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -83,10 +90,31 @@ final class WorryDecisionVC: BaseVC {
     
     private func setPressAction() {
         self.doneButton.press {
-            print("완료 버튼 액션")
+            // 고민 완료 Post
+            self.showWorryQuote()
         }
     }
-   
+    
+    private func showWorryQuote() {
+        self.mainView.isHidden = true
+
+        UIView.animate(withDuration: 0.7, animations: {
+            self.quoteView.alpha = 1.0
+        })
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.3) {
+            UIView.animate(withDuration: 0.5, animations: {
+                self.quoteView.alpha = 0.0
+            })
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
+            self.dismiss(animated: false, completion: nil)
+        }
+    }
+    
+    func setTemplateId(id: Int) {
+        self.templateId = id
+    }
 
 }
 // MARK: - Keyboard Setting
@@ -214,7 +242,7 @@ extension WorryDecisionVC: UITextViewDelegate {
 // MARK: - UI
 extension WorryDecisionVC {
     private func setLayout() {
-        self.view.addSubview(mainView)
+        self.view.addSubviews([quoteView,mainView])
         
         mainView.addSubviews([pickaxeImageView, mainTitle, subTitle, worryTextView, doneButton])
         
@@ -251,6 +279,12 @@ extension WorryDecisionVC {
             $0.bottom.equalToSuperview().inset(38)
             $0.height.equalTo(30)
             $0.width.equalTo(78)
+        }
+
+        quoteView.snp.makeConstraints {
+            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(284.adjustedH)
+            $0.height.equalTo(244.adjustedH)
         }
     }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -39,8 +39,7 @@ final class WorryDecisionVC: BaseVC {
         $0.font = .kB4R14
         $0.textColor = .kGray3
         $0.isScrollEnabled = false
-        
-        $0.textContainerInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
+        $0.textContainerInset = UIEdgeInsets(top: 12, left: 5, bottom: 0, right: 0)
     }
     
     private let doneButton = UIButton().then {
@@ -52,9 +51,13 @@ final class WorryDecisionVC: BaseVC {
         $0.layer.cornerRadius = 8
     }
     
-    private let topInset: CGFloat = 303
+    private let topInset: CGFloat = 303.adjustedH
     private var hasKeyboard: Bool = false
     private let placeholderText = "40자 이내로 적어주세요."
+    /// TextView의 content 기본 높이 27을 뺀 뷰의 높이
+    private var defaultTextHeight: CGFloat = 27.7
+    private lazy var defaultTextViewHeight: CGFloat = (40 - defaultTextHeight).adjustedH
+    private lazy var defaultMainViewHeight: CGFloat = (282 - defaultTextHeight).adjustedH
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -63,6 +66,7 @@ final class WorryDecisionVC: BaseVC {
         setLayout()
         hideKeyboardWhenTappedAround()
         setTextView()
+        setPressAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -175,6 +179,10 @@ extension WorryDecisionVC: UITextViewDelegate {
         )
         
         textView.attributedText = attributedText
+        
+        let fixedWidth = textView.frame.size.width
+        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        print("일",newSize.height)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -185,12 +193,30 @@ extension WorryDecisionVC: UITextViewDelegate {
             textView.font = .kB4R14
             textView.textColor = .kGray3
         }
+        
+        let fixedWidth = textView.frame.size.width
+        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        print("이",newSize.height)
     }
     
     func textViewDidChange(_ textView: UITextView) {
+        
+        guard !textView.text.isEmpty else { return }
+        
         if textView.text.count > 40 {
             textView.deleteBackward()
         }
+       
+        let fixedWidth = textView.frame.size.width
+        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        worryTextView.snp.updateConstraints {
+            $0.height.equalTo(newSize.height + defaultTextViewHeight)
+        }
+
+        mainView.snp.updateConstraints {
+            $0.height.equalTo(newSize.height + defaultMainViewHeight)
+        }
+        print("삼", newSize.height)
     }
 }
 
@@ -204,7 +230,7 @@ extension WorryDecisionVC {
         mainView.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalToSuperview().inset(19)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(topInset.adjustedH)
-            $0.height.equalTo(282.adjustedH)
+            $0.height.equalTo(defaultMainViewHeight + defaultTextHeight)
         }
         
         pickaxeImageView.snp.makeConstraints {
@@ -226,7 +252,7 @@ extension WorryDecisionVC {
         worryTextView.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalToSuperview().inset(18)
             $0.top.equalTo(subTitle.snp.bottom).offset(16)
-            $0.height.equalTo(40)
+            $0.height.equalTo(defaultTextViewHeight + defaultTextHeight)
         }
         
         doneButton.snp.makeConstraints {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -108,7 +108,10 @@ final class WorryDecisionVC: BaseVC {
             })
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
-            self.dismiss(animated: false, completion: nil)
+            if let worryDetailVC = self.presentingViewController {
+                self.dismiss(animated: true)
+                worryDetailVC.dismiss(animated: true)
+            }
         }
     }
     

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -1,0 +1,29 @@
+//
+//  WorryDecisionVC.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/08/03.
+//
+
+import UIKit
+
+class WorryDecisionVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -78,6 +78,12 @@ final class WorryDecisionVC: BaseVC {
         worryTextView.delegate = self
     }
     
+    private func setPressAction() {
+        self.doneButton.press {
+            print("완료 버튼 액션")
+        }
+    }
+   
 
 }
 // MARK: - Keyboard Setting
@@ -148,6 +154,43 @@ extension WorryDecisionVC {
         
         ///  키보드가 내려가 있었을 때와 키보드가 올라왔있다가 내려가고 호출되어 false 고정
         hasKeyboard = false
+    }
+}
+
+// MARK: - TextView Delegate
+extension WorryDecisionVC: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        var inputText = ""
+        inputText = textView.text == placeholderText ? " " : textView.text
+        /// 행간 간격 150% 설정
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = UIFont.kB4R14.lineHeight * 0.5
+        let attributedText = NSAttributedString(
+            string: inputText,
+            attributes: [
+                .paragraphStyle: style,
+                .foregroundColor: UIColor.kGray1,
+                .font: UIFont.kB4R14
+            ]
+        )
+        
+        textView.attributedText = attributedText
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if trimmedText.isEmpty {
+            textView.text = placeholderText
+            textView.font = .kB4R14
+            textView.textColor = .kGray3
+        }
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        if textView.text.count > 40 {
+            textView.deleteBackward()
+        }
     }
 }
 

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
@@ -1,0 +1,20 @@
+//
+//  WorryQuoteView.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/08/07.
+//
+
+import UIKit
+
+class WorryQuoteView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
@@ -6,15 +6,76 @@
 //
 
 import UIKit
+import SnapKit
+import Then
 
-class WorryQuoteView: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+final class WorryQuoteView: UIView {
+    
+    private var quoteString: String = ""
+    
+    private let gemImage = UIImageView().then {
+        $0.image = UIImage(named: "gem_red_l")
     }
-    */
+    private let titleLabel = UILabel().then {
+        $0.text = "이 고민을 통해 더욱 빛나기를!"
+        $0.textColor = .kWhite
+        $0.font = .kH3B18
+    }
+    private let subTitleLabel = UILabel().then {
+        $0.text = ""
+        $0.textAlignment = .center
+        $0.textColor = .kWhite
+        $0.font = .kMoR13
+        $0.numberOfLines = 2
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        // 랜덤 명언 데이터 선택
+        getRandomQuote()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func getRandomQuote() {
+        let text = "고민하면서 길을 찾는 사람들, 그들은 참된 인간상이다\n- 파스칼 -"
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = UIFont.kB4R14.lineHeight * 0.6
+        style.alignment = .center
+        let attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .paragraphStyle: style,
+                .foregroundColor: UIColor.kWhite,
+                .font: UIFont.kMoR13
+            ]
+        )
+        subTitleLabel.attributedText = attributedText
+    }
+    
+}
 
+// MARK: - UI
+extension WorryQuoteView {
+    private func setLayout() {
+        self.addSubviews([gemImage, titleLabel, subTitleLabel])
+        
+        gemImage.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().inset(22)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(gemImage.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+        }
+        
+        subTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(23)
+            $0.centerX.equalToSuperview()
+        }
+    }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- 고민캐기 완료버튼 클릭시 작성하는 모달창과 입력 완료시 2초?간 뜨는 명언 창으로 구현하였습니다.
 - WorryDecisionVC를 통해 해당 뷰를 구현하고 고민 입력 뷰를 mainView에 담아 띄워주고 입력 완료시 mainView를 숨기고 명언 뷰(QuoteView)를 띄우는 식으로 한 VC내에서 구현되도록 하였습니다.

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 고민작성 모달에 고민작성 부분을 textView로 구현하여 이전과 같이 키보드 observer를 이용해 키보드 동작 처리를 하고 텍스뷰의 높이 또한 동적으로 동적하도록 하면서 - 기획 요구사항에 맞게 늘어나는 높이는 두 줄정도까지만 늘어나도록 했고, 40자 글자수 제한을 적용하였습니다. 
- 모달창 배경에 이전 VC가 반투명하게 보여지도록 하기 위해 WorryDecisionVC의 배경의 alpha 값을 0.5로 조정하였습니다.

- QuoteView가 서서히 나타나도록 alpha 값을 1.0으로 바꿔주는 것을 UIView.animate를 이용해서 구현해줬는데 - (1) 다시 사라지게할때는 UIView.animate만 적용하면 (1)의 코드 실행 후 바로 실행이 되어버려 서서히 나타나기 전에 코드가 적용이 되어 `DispatchQueue.main.asyncAfter(deadline: .now() + 2.3) ` 를 이용해 (1)의 duration이 끝나고 사라지는 코드가 실행되도록 해주었습니다. 
- 이후 서서히 안보이면서 창을 dismiss시켜야하는데 홈에서 고민상세, 캐기완료 VC 2개가 present된 형태라 2개의 VC를 순차적으로 dismiss시켜줘야 했습니다 그래서 현재의 VC를 띄워주는 고민 상세 VC를 self.presentingViewController를 이용해서 가져와서 self를 이용해서 고민캐기 VC를 dismiss하고, 그 이전 VC를 dismiss할 수 있도록 하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-08-13 at 12 58 08](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/78127cbd-76e3-40f4-9b88-921dffbf52c0)


## 🚨 관련 이슈
- Resolved: #27 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
