### PR TITLE
[Feat] 네트워크 기본 세팅 & 홈 고민목록 조회 API 서버연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,6 @@ iOSInjectionProject/
 !*.xcodeproj/xcshareddata/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
+*.xcconfig
 
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode,macos,cocoapods

--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -64,8 +64,6 @@
 		E79AAC5A2A531E3300F3F439 /* NanumMyeongjoOTF.otf in Resources */ = {isa = PBXBuildFile; fileRef = E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */; };
 		E7AC12212A51CFFD00FE504C /* GeneralResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */; };
 		E7AC12232A51D08300FE504C /* Temp_DataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12222A51D08300FE504C /* Temp_DataModel.swift */; };
-		E7AC12252A51D08C00FE504C /* Temp_Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12242A51D08C00FE504C /* Temp_Service.swift */; };
-		E7AC12272A51D09200FE504C /* Temp_API.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12262A51D09200FE504C /* Temp_API.swift */; };
 		E7AC122F2A51D54900FE504C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC122E2A51D54900FE504C /* CombineMoya */; };
 		E7AC12312A51D54900FE504C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC12302A51D54900FE504C /* Moya */; };
 		E7AC12342A51D56F00FE504C /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC12332A51D56F00FE504C /* SnapKit */; };
@@ -146,8 +144,6 @@
 		E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumMyeongjoOTF.otf; sourceTree = "<group>"; };
 		E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralResponse.swift; sourceTree = "<group>"; };
 		E7AC12222A51D08300FE504C /* Temp_DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp_DataModel.swift; sourceTree = "<group>"; };
-		E7AC12242A51D08C00FE504C /* Temp_Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp_Service.swift; sourceTree = "<group>"; };
-		E7AC12262A51D09200FE504C /* Temp_API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp_API.swift; sourceTree = "<group>"; };
 		E7BB4F3A2A5ED3610018312B /* HomeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVC.swift; sourceTree = "<group>"; };
 		E7BB4F462A5EF7060018312B /* HomeGemListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemListViewModel.swift; sourceTree = "<group>"; };
 		E7BB4F482A5EF7320018312B /* HomeGemListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemListModel.swift; sourceTree = "<group>"; };
@@ -400,7 +396,6 @@
 		E7AC121C2A51CF8E00FE504C /* APIs */ = {
 			isa = PBXGroup;
 			children = (
-				E7AC12262A51D09200FE504C /* Temp_API.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -408,7 +403,6 @@
 		E7AC121D2A51CF9600FE504C /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				E7AC12242A51D08C00FE504C /* Temp_Service.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -641,7 +635,6 @@
 				E79AAC342A52F2C300F3F439 /* UIViewController+.swift in Sources */,
 				E79AAC332A52F2C300F3F439 /* UITextField+.swift in Sources */,
 				E79AAC322A52F2C300F3F439 /* UIColor+.swift in Sources */,
-				E7AC12252A51D08C00FE504C /* Temp_Service.swift in Sources */,
 				E73CA3E22A6A688A00BAC9D6 /* CustomNavigationBarView.swift in Sources */,
 				85887D972A60430600F7FB21 /* ArchiveModalCVC.swift in Sources */,
 				E79AAC372A52F2C300F3F439 /* CALayer+.swift in Sources */,
@@ -659,7 +652,6 @@
 				E79AAC4B2A52F3E000F3F439 /* BaseNC.swift in Sources */,
 				E79AAC462A52F36500F3F439 /* NetworkConstant.swift in Sources */,
 				85EBC7F52A5AD94100B9E891 /* WriteVC.swift in Sources */,
-				E7AC12272A51D09200FE504C /* Temp_API.swift in Sources */,
 				E73CA3DA2A69300F00BAC9D6 /* HomePublisherModel.swift in Sources */,
 				85887D9E2A61219700F7FB21 /* TemplateInfoHeaderView.swift in Sources */,
 				E79AAC4A2A52F3E000F3F439 /* BaseVC.swift in Sources */,

--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		85EBC7F32A5AD93200B9E891 /* HomeGemStoneVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */; };
 		85EBC7F52A5AD94100B9E891 /* WriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F42A5AD94100B9E891 /* WriteVC.swift */; };
 		85EBC7F72A5AD95D00B9E891 /* ArchiveVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F62A5AD95D00B9E891 /* ArchiveVC.swift */; };
+		E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA02A90959A006B2E74 /* HomeService.swift */; };
+		E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA22A909829006B2E74 /* HomeAPI.swift */; };
 		E721EABD2A51D5D900A04AA0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E721EABC2A51D5D900A04AA0 /* Then */; };
 		E73CA3DA2A69300F00BAC9D6 /* HomePublisherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */; };
 		E73CA3DC2A693C9D00BAC9D6 /* GemStoneEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */; };
@@ -109,6 +111,8 @@
 		85EBC7F42A5AD94100B9E891 /* WriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteVC.swift; sourceTree = "<group>"; };
 		85EBC7F62A5AD95D00B9E891 /* ArchiveVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveVC.swift; sourceTree = "<group>"; };
 		E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		E70C7CA02A90959A006B2E74 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
+		E70C7CA22A909829006B2E74 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
 		E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePublisherModel.swift; sourceTree = "<group>"; };
 		E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GemStoneEmptyView.swift; sourceTree = "<group>"; };
 		E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailVC.swift; sourceTree = "<group>"; };
@@ -396,6 +400,7 @@
 		E7AC121C2A51CF8E00FE504C /* APIs */ = {
 			isa = PBXGroup;
 			children = (
+				E70C7CA22A909829006B2E74 /* HomeAPI.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -403,6 +408,7 @@
 		E7AC121D2A51CF9600FE504C /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				E70C7CA02A90959A006B2E74 /* HomeService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -635,6 +641,7 @@
 				E79AAC342A52F2C300F3F439 /* UIViewController+.swift in Sources */,
 				E79AAC332A52F2C300F3F439 /* UITextField+.swift in Sources */,
 				E79AAC322A52F2C300F3F439 /* UIColor+.swift in Sources */,
+				E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */,
 				E73CA3E22A6A688A00BAC9D6 /* CustomNavigationBarView.swift in Sources */,
 				85887D972A60430600F7FB21 /* ArchiveModalCVC.swift in Sources */,
 				E79AAC372A52F2C300F3F439 /* CALayer+.swift in Sources */,
@@ -657,6 +664,7 @@
 				E79AAC4A2A52F3E000F3F439 /* BaseVC.swift in Sources */,
 				85A8492D2A87A3FF009F1468 /* TemplateContentModel.swift in Sources */,
 				E79AAC3B2A52F2C300F3F439 /* UIButton+.swift in Sources */,
+				E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */,
 				E79AAC452A52F36500F3F439 /* MoyaLoggingPlugin.swift in Sources */,
 				85A849332A87DA36009F1468 /* TemplateContentHeaderView.swift in Sources */,
 				E7BB4F552A604FC10018312B /* GemStoneCVC.swift in Sources */,

--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemStoneVC.swift; sourceTree = "<group>"; };
 		85EBC7F42A5AD94100B9E891 /* WriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteVC.swift; sourceTree = "<group>"; };
 		85EBC7F62A5AD95D00B9E891 /* ArchiveVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveVC.swift; sourceTree = "<group>"; };
+		E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePublisherModel.swift; sourceTree = "<group>"; };
 		E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GemStoneEmptyView.swift; sourceTree = "<group>"; };
 		E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailVC.swift; sourceTree = "<group>"; };
@@ -391,6 +392,7 @@
 				E7AC121E2A51CF9D00FE504C /* DataModels */,
 				E7AC121D2A51CF9600FE504C /* Services */,
 				E7AC121C2A51CF8E00FE504C /* APIs */,
+				E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -828,6 +830,7 @@
 		};
 		E7C808FA2A4D37FA00F475CE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/KAERA/KAERA/Application/Info.plist
+++ b/KAERA/KAERA/Application/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
+	<key>BEARER_TOKEN</key>
+	<string>$(BEARER_TOKEN)</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>.</string>
 	<key>UIAppFonts</key>

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -1,0 +1,45 @@
+//
+//  HomeAPI.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/08/19.
+//
+
+import Foundation
+import Moya
+
+final class HomeAPI {
+    
+    static let shared: HomeAPI = HomeAPI()
+    private let homeProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggingPlugin()])
+    
+    private init() { }
+    
+    public private(set) var homeWorryListResponse: GeneralArrayResponse<HomeGemListModel>?
+    
+   
+    // MARK: - WorryAlone
+    func getHomeWorryList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
+        homeProvider.request(.homeWorryList(isSolved: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.homeWorryListResponse = try
+                    result.map(GeneralArrayResponse<HomeGemListModel>?.self)
+                    print("성공")
+                    print(result)
+                    guard let worryList = self?.homeWorryListResponse else { return }
+                    print(worryList)
+                    completion(worryList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+}
+

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -15,22 +15,22 @@ final class HomeAPI {
     
     private init() { }
     
-    public private(set) var homeWorryListResponse: GeneralArrayResponse<HomeGemListModel>?
+    public private(set) var homeGemListResponse: GeneralArrayResponse<HomeGemListModel>?
     
    
-    // MARK: - WorryAlone
-    func getHomeWorryList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
-        homeProvider.request(.homeWorryList(isSolved: param)) { [weak self] response in
+    // MARK: - HomeGemList
+    func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
+        homeProvider.request(.homeGemList(isSolved: param)) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
-                    self?.homeWorryListResponse = try
+                    self?.homeGemListResponse = try
                     result.map(GeneralArrayResponse<HomeGemListModel>?.self)
                     print("성공")
                     print(result)
-                    guard let worryList = self?.homeWorryListResponse else { return }
-                    print(worryList)
-                    completion(worryList)
+                    guard let gemList = self?.homeGemListResponse else { return }
+                    print(gemList)
+                    completion(gemList)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/APIs/Temp_API.swift
+++ b/KAERA/KAERA/Network/APIs/Temp_API.swift
@@ -1,8 +1,0 @@
-//
-//  Temp_API.swift
-//  KAERA
-//
-//  Created by 김담인 on 2023/07/03.
-//
-
-import Foundation

--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -11,5 +11,12 @@ import Foundation
 struct APIConstant {
     
     //MARK: - Base
-    static let baseURL = ""
+    static let baseURL = {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
+            fatalError("Base URL not set in plist for this environment")
+        }
+        return url
+    }()
+    
+    static let homeWorryList = "/worry/list"
 }

--- a/KAERA/KAERA/Network/Base/NetworkConstant.swift
+++ b/KAERA/KAERA/Network/Base/NetworkConstant.swift
@@ -11,8 +11,15 @@ struct NetworkConstant {
     
     static let noTokenHeader = ["Content-Type": "application/json"]
     
-//    static let hasTokenHeader = ["Content-Type": "application/json",
-//                                 "Authorization": NetworkConstant.accessToken]
-//
-//    static var accessToken = "토큰값"
+    static let hasTokenHeader = ["Content-Type": "application/json",
+                                 "Authorization": NetworkConstant.bearerToken]
+    
+    /// 임시로 현재 고정  bearerToken 직접 사용
+    static let bearerToken = {
+        guard let token = Bundle.main.object(forInfoDictionaryKey: "BEARER_TOKEN") as? String else {
+            fatalError("Base URL not set in plist for this environment")
+        }
+        return token
+    }()
+    
 }

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -1,0 +1,44 @@
+//
+//  HomeService.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/08/19.
+//
+
+import Foundation
+import Moya
+
+enum HomeService {
+    case homeWorryList(isSolved: Int)
+}
+
+extension HomeService: BaseTargetType {
+    
+    var path: String {
+        switch self {
+        case .homeWorryList(let isSolved):
+            return APIConstant.homeWorryList + "/\(isSolved)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .homeWorryList:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .homeWorryList:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String : String]? {
+        switch self {
+        case .homeWorryList:
+            return NetworkConstant.hasTokenHeader
+        }
+    }
+}

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -9,35 +9,35 @@ import Foundation
 import Moya
 
 enum HomeService {
-    case homeWorryList(isSolved: Int)
+    case homeGemList(isSolved: Int)
 }
 
 extension HomeService: BaseTargetType {
     
     var path: String {
         switch self {
-        case .homeWorryList(let isSolved):
+        case .homeGemList(let isSolved):
             return APIConstant.homeWorryList + "/\(isSolved)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .homeWorryList:
+        case .homeGemList:
             return .get
         }
     }
     
     var task: Task {
         switch self {
-        case .homeWorryList:
+        case .homeGemList:
             return .requestPlain
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeWorryList:
+        case .homeGemList:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Network/Services/Temp_Service.swift
+++ b/KAERA/KAERA/Network/Services/Temp_Service.swift
@@ -1,8 +1,0 @@
-//
-//  Temp_Service.swift
-//  KAERA
-//
-//  Created by 김담인 on 2023/07/03.
-//
-
-import Foundation

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -56,6 +56,9 @@ final class HomeGemStoneVC: BaseVC {
     
     private let gemStoneEmptyView = GemStoneEmptyView(mainTitle: "아직 고민 보석이 없네요!", subTitle: "작성된 고민 원석을\n빛나는 보석으로 만들어주세요.")
     
+    private let gemIndexDict: [Int:Int] = [0:0, 1:3, 2:9, 3:6, 4:1, 5:8, 6:11, 7:7, 8:4, 9:2, 10:10, 11:5]
+    private let totalGemStoneNum = 12
+    
     // MARK: - Initialization
     init(type: PageType = .digging) {
         super.init(nibName: nil, bundle: nil)
@@ -126,7 +129,8 @@ final class HomeGemStoneVC: BaseVC {
 // MARK: - CollectionView
 extension HomeGemStoneVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let worryId = gemStoneList[indexPath.row].worryId
+        guard let idx = gemIndexDict[indexPath.item], idx < gemStoneList.count else { return }
+        let worryId = gemStoneList[idx].worryId
         let vc = HomeWorryDetailVC(worryId: worryId, type: pageType)
         vc.modalPresentationStyle = .fullScreen
         vc.modalTransitionStyle = .coverVertical
@@ -136,15 +140,33 @@ extension HomeGemStoneVC: UICollectionViewDelegate {
 
 extension HomeGemStoneVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return gemStoneList.count
+        switch pageType {
+        case .digging:
+            return totalGemStoneNum
+        case .dug:
+            return gemStoneList.count
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let gemStoneCell = collectionView.dequeueReusableCell(withReuseIdentifier: GemStoneCVC.className, for: indexPath) as! GemStoneCVC
-        
-        let title = gemStoneList[indexPath.row].title
-        let imageName = gemStoneList[indexPath.row].imageName
-        gemStoneCell.setData(title: title, imageName: imageName)
+        switch pageType {
+        case .digging:
+            if let idx = gemIndexDict[indexPath.item], idx < gemStoneList.count {
+                gemStoneCell.isHidden = false
+                let title = gemStoneList[idx].title
+                let imageName = gemStoneList[idx].imageName
+                gemStoneCell.setData(title: title, imageName: imageName)
+            }else {
+                gemStoneCell.isHidden = true
+            }
+        case .dug:
+            let title = gemStoneList[indexPath.item].title
+            let imageName = gemStoneList[indexPath.item].imageName
+            gemStoneCell.setData(title: title, imageName: imageName)
+        }
+     
+       
         return gemStoneCell
     }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -21,7 +21,7 @@ final class HomeGemStoneVC: BaseVC {
     // MARK: - Properties
     private let gemListViewModel = HomeGemListViewModel()
     private var cancellables = Set<AnyCancellable>()
-    private let input = PassthroughSubject<Bool, Never>.init()
+    private let input = PassthroughSubject<Int, Never>.init()
     private var gemStoneList: [HomePublisherModel] = []
     
     private let gemStoneCV = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -78,9 +78,9 @@ final class HomeGemStoneVC: BaseVC {
     
     override func viewWillAppear(_ animated: Bool) {
         if pageType == .digging {
-            input.send(false)
+            input.send(0)
         }else if pageType == .dug {
-            input.send(true)
+            input.send(1)
         }
     }
     
@@ -98,9 +98,9 @@ final class HomeGemStoneVC: BaseVC {
     private func dataBind() {
         let output = gemListViewModel.transform(
             input: HomeGemListViewModel
-                .Input(isSolved: input.eraseToAnyPublisher())
+                .Input(input)
         )
-        output.dataList.receive(on: DispatchQueue.main)
+        output.receive(on: DispatchQueue.main)
             .sink { [weak self] list in
                 self?.updateUI(gemList: list)
             }.store(in: &cancellables)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -140,7 +140,7 @@ final class HomeWorryDetailVC: BaseVC {
         self.removeKeyboardObserver()
     }
     
-    
+    // MARK: - Function
     private func addKeyboardObserver() {
         NotificationCenter.default.addObserver(
             self,

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -285,7 +285,7 @@ extension WorryDecisionVC {
         }
 
         quoteView.snp.makeConstraints {
-            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(284.adjustedH)
             $0.height.equalTo(244.adjustedH)
         }

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
@@ -49,61 +49,7 @@ final class HomeGemListViewModel: ViewModelType {
     ]
     
     private var gemStoneList: [HomePublisherModel] = []
-    /// 서버에서 받아올 데이터 모델 배열
-    private var gemStoneListDummy: [HomeGemListModel] = [
-        HomeGemListModel(worryId: 1, templateId: 1, title: "고민중1"),
-        HomeGemListModel(worryId: 2, templateId: 2, title: "고민중2"),
-        HomeGemListModel(worryId: 3, templateId: 3, title: "고민중3"),
-        HomeGemListModel(worryId: 4, templateId: 4, title: "고민중4"),
-        HomeGemListModel(worryId: 5, templateId: 5, title: "고민중5"),
-        HomeGemListModel(worryId: 6, templateId: 6, title: "고민중6"),
-        HomeGemListModel(worryId: 7, templateId: 1, title: "고민중7"),
-        HomeGemListModel(worryId: 8, templateId: 2, title: "고민중8"),
-        HomeGemListModel(worryId: 9, templateId: 3, title: "고민중9"),
-        HomeGemListModel(worryId: 10, templateId: 4, title: "고민중10"),
-        HomeGemListModel(worryId: 11, templateId: 5, title: "고민중11"),
-        HomeGemListModel(worryId: 12, templateId: 6, title: "고민중12"),
-    ]
-    private var gemListDummy: [HomeGemListModel] = [
-        HomeGemListModel(worryId: 1, templateId: 1, title: "고민완료1"),
-        HomeGemListModel(worryId: 2, templateId: 2, title: "고민완료2"),
-        HomeGemListModel(worryId: 3, templateId: 3, title: "고민완료3"),
-        HomeGemListModel(worryId: 4, templateId: 4, title: "고민완료4"),
-        HomeGemListModel(worryId: 5, templateId: 5, title: "고민완료5"),
-        HomeGemListModel(worryId: 6, templateId: 6, title: "고민완료6"),
-        HomeGemListModel(worryId: 7, templateId: 1, title: "고민완료7"),
-        HomeGemListModel(worryId: 8, templateId: 2, title: "고민완료8"),
-        HomeGemListModel(worryId: 9, templateId: 3, title: "고민완료9"),
-        HomeGemListModel(worryId: 10, templateId: 4, title: "고민완료10"),
-        HomeGemListModel(worryId: 11, templateId: 5, title: "고민완료11"),
-        HomeGemListModel(worryId: 12, templateId: 6, title: "고민완료12"),
-    ]
-    
-    // MARK: - Function
-    private func getGemList(isSovled: Int) {
-        /// 서버 통신을 통해 getStoneList를 업데이트
-        /// 여기서는 더미로 업데이트
-        ///  서버 연결시 if 문 필요 없이 gemStoneList만 사용
-        if isSovled > 0 {
-            gemStoneList = []
-            gemListDummy.forEach {
-                let image = gemStoneDictionary[TemplateKey(id: $0.templateId, isSolved: isSovled)] ?? "gemstone_pink"
-                let data = HomePublisherModel(worryId: $0.worryId, templateId: $0.templateId, imageName: image, title: $0.title)
-                gemStoneList.append(data)
-            }
-            self.output.send(gemStoneList)
-        } else {
-            gemStoneList = []
-            gemStoneListDummy.forEach {
-                let image = gemStoneDictionary[TemplateKey(id: $0.templateId, isSolved: isSovled)] ?? "gem_pink_l"
-                let data = HomePublisherModel(worryId: $0.worryId, templateId: $0.templateId, imageName: image, title: $0.title)
-                gemStoneList.append(data)
-            }
-            self.output.send(gemStoneList)
-        }
-        
-        
-    }
+
 }
 // MARK: - Network
 extension HomeGemListViewModel {

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
@@ -108,7 +108,7 @@ final class HomeGemListViewModel: ViewModelType {
 // MARK: - Network
 extension HomeGemListViewModel {
     private func getHomeGemList(isSolved: Int) {
-        HomeAPI.shared.getHomeWorryList(param: isSolved) { res in
+        HomeAPI.shared.getHomeGemList(param: isSolved) { res in
             guard let res = res, let data = res.data else { return }
             /// 뿌려줄 리스트 초기화
             self.gemStoneList = []

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
@@ -9,45 +9,43 @@ import Foundation
 import Combine
 
 final class HomeGemListViewModel: ViewModelType {
-    struct Input {
-        let isSolved: AnyPublisher<Bool, Never>
-    }
-    struct Output {
-        let dataList: AnyPublisher<[HomePublisherModel], Never>
-    }
+
+    typealias Input = AnyPublisher<Int, Never>
+    typealias Output = AnyPublisher<[HomePublisherModel], Never>
     
     private let output: PassthroughSubject<[HomePublisherModel], Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     
     func transform(input: Input) -> Output {
-        input.isSolved
+        input
             .sink { [weak self] isSolved in
-                self?.getGemList(isSovled: isSolved)
+//                self?.getGemList(isSovled: isSolved)
+                self?.getHomeGemList(isSolved: isSolved)
             }
             .store(in: &cancellables)
-        return Output(dataList: output.eraseToAnyPublisher())
+        return output.eraseToAnyPublisher()
     }
     
     
     // MARK: - Properties
     struct TemplateKey: Hashable {
         let id: Int
-        let isSolved: Bool
+        let isSolved: Int
     }
     
     private var gemStoneDictionary: [TemplateKey: String] = [
-        TemplateKey(id: 1, isSolved: false): "gemstone_pink",
-        TemplateKey(id: 1, isSolved: true): "gem_pink_l",
-        TemplateKey(id: 2, isSolved: false): "gemstone_orange",
-        TemplateKey(id: 2, isSolved: true): "gem_orange_l",
-        TemplateKey(id: 3, isSolved: false): "gemstone_blue",
-        TemplateKey(id: 3, isSolved: true): "gem_blue_l",
-        TemplateKey(id: 4, isSolved: false): "gemstone_green",
-        TemplateKey(id: 4, isSolved: true): "gem_green_l",
-        TemplateKey(id: 5, isSolved: false): "gemstone_yellow",
-        TemplateKey(id: 5, isSolved: true): "gem_yellow_l",
-        TemplateKey(id: 6, isSolved: false): "gemstone_red",
-        TemplateKey(id: 6, isSolved: true): "gem_red_l",
+        TemplateKey(id: 1, isSolved: 0): "gemstone_pink",
+        TemplateKey(id: 1, isSolved: 1): "gem_pink_l",
+        TemplateKey(id: 2, isSolved: 0): "gemstone_orange",
+        TemplateKey(id: 2, isSolved: 1): "gem_orange_l",
+        TemplateKey(id: 3, isSolved: 0): "gemstone_blue",
+        TemplateKey(id: 3, isSolved: 1): "gem_blue_l",
+        TemplateKey(id: 4, isSolved: 0): "gemstone_green",
+        TemplateKey(id: 4, isSolved: 1): "gem_green_l",
+        TemplateKey(id: 5, isSolved: 0): "gemstone_yellow",
+        TemplateKey(id: 5, isSolved: 1): "gem_yellow_l",
+        TemplateKey(id: 6, isSolved: 0): "gemstone_red",
+        TemplateKey(id: 6, isSolved: 1): "gem_red_l",
     ]
     
     private var gemStoneList: [HomePublisherModel] = []
@@ -82,11 +80,11 @@ final class HomeGemListViewModel: ViewModelType {
     ]
     
     // MARK: - Function
-    private func getGemList(isSovled: Bool) {
+    private func getGemList(isSovled: Int) {
         /// 서버 통신을 통해 getStoneList를 업데이트
         /// 여기서는 더미로 업데이트
         ///  서버 연결시 if 문 필요 없이 gemStoneList만 사용
-        if isSovled {
+        if isSovled > 0 {
             gemStoneList = []
             gemListDummy.forEach {
                 let image = gemStoneDictionary[TemplateKey(id: $0.templateId, isSolved: isSovled)] ?? "gemstone_pink"

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
@@ -105,3 +105,22 @@ final class HomeGemListViewModel: ViewModelType {
         
     }
 }
+// MARK: - Network
+extension HomeGemListViewModel {
+    private func getHomeGemList(isSolved: Int) {
+        HomeAPI.shared.getHomeWorryList(param: isSolved) { res in
+            guard let res = res, let data = res.data else { return }
+            /// 뿌려줄 리스트 초기화
+            self.gemStoneList = []
+            
+            data.forEach {
+                let image = self.gemStoneDictionary[TemplateKey(id: $0.templateId, isSolved: isSolved)] ?? "gemstone_pink"
+                let publisherModel = HomePublisherModel(worryId: $0.worryId, templateId: $0.templateId, imageName: image, title: $0.title)
+                self.gemStoneList.append(publisherModel)
+            }
+            
+            self.output.send(self.gemStoneList)
+        }
+
+    }
+}


### PR DESCRIPTION
## 💪 작업한 내용
-  서버에서 알려준 BaseURL과 BearerToken 값은 git에 올라가면 안되는 민감한 정보이므로 xcconifg에 저장하고 설정파일을 통해 사용할 수 있도록 하였습니다.
  - 위 url및 token 값을 담은 xcconfig 파일은 당분간은 따로 로컬에서 프로젝트에 추가해 사용해주시면 됩니다. (로그인 구현시 서버를 통해 토큰 값을 가져올 것임)
  - 그래서 네트워크 폴더내에 NetworkConstant에 토큰을, APIConstant에 baseURL 값을 가져와 사용할 수 있도록 했습니다.
  
- 세팅한 url과 token이 잘 사용되는지 확인하고자 Home 화면에 고민 리스트를 가져오는 API 연결까지 이번에 구현하였습니다.
  - APIConstant에 path url을 추가해주고 
  - HomeService를 만들어 명세서에 맞게 구현을 해주고 (Get방식, header내 토큰 여부 등)
   - HomeAPI를 만들어 홈에 뿌려줄 gemList를 서버에서 받아오는 함수를 구현하고
   - HomeGemListViewModel에서 기존에 더미 데이터로 넣어줬던 gemList를 서버 통신을 통해 gemList를 받아와 업데이트 하였습니다. 
     - 서버에서 받아오는 리스폰스 모델과 뿌려주는 publiserModel이 달라 따로 매핑하는 과정을 추가하였습니다.

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 본 브랜치 머지 후  따로 전해드리는 xcconfig 파일을 네트워크 폴더에 추가해서 사용해주세요 
- 현재는 임시로 xcconfig 파일에 API 정보를 담아 사용하지만 이후에는 서버에서 엑세스 토큰을 받아 키체인을 통해 관리하고자 합니다. (써보진 않아서 잘 모릅니다..)

- 처음에 gemList 받아오는것을 실패했는데 원인이 명세서에 고민중, 고민완료시의 데이터를 구분하기 위해 요청하는 isSolved값이 param으로 들어가는 줄 알고 HomeService에 param을 추가해 구현해줬는데 다시 보니 단순히 path에 "/isSolved" 로 값을 추가해주는 것이여서 해당 부분 수정하고 서버 연결에 성공 할 수 있었습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="696" alt="Screenshot 2023-08-20 at 2 29 28 PM" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/dd045fce-6815-44b5-93b7-733e115110a7">

| 홈 고민 중 | 홈 고민 완료 | 
| ------- | --------- |
| ![Simulator Screenshot - iPhone 13 mini - 2023-08-20 at 14 29 39](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/764f2d0a-ceac-4370-a9d8-30e16e99f915) | ![Simulator Screenshot - iPhone 13 mini - 2023-08-20 at 14 29 46](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/adc2c7e2-5673-495a-8c77-b516cf641028) |


## 🚨 관련 이슈
- Resolved: #32 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
