### PR TITLE
[Feat] 고민작성뷰 키보드 동작 구현

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -14,11 +14,3 @@ struct TemplateContentModel {
     let questions: [String]
     let hints: [String]
 }
-
-/// View에 뿌려주기 위한 model
-//struct TemplateContentPublisherModel {
-//    let templateId: Int
-//    let templateTitle: String
-//    let templateDetail: String
-//    let image: UIImage
-//}

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
@@ -89,9 +89,7 @@ extension ArchiveModalVC{
     
     /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
     fileprivate func setBindings() {
-        print("ViewController - setBindings()")
         self.templateVM.templateListPublisher.sink{ [weak self] (updatedList : [TemplateListPublisherModel]) in
-            print("ViewController - updatedList.count: \(updatedList.count)")
             self?.templateList = updatedList
         }.store(in: &disposalbleBag)
     }

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -33,7 +33,6 @@ class WorryListViewModel {
     lazy var worryListPublisher = CurrentValueSubject<[WorryListPublisherModel], Never>(worryUpdateList)
     
     init() {
-        print("ViewModel - init()")
         worryUpdateList = []
         convertIdtoImg()
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -69,16 +69,12 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
             $0.height.equalTo(1.adjustedW)
         }
     }
-    
-    func resignTextField() {
-//        worryTitleTextField.resignFirstResponder()
-        worryTitleTextField.becomeFirstResponder()
-    }
 }
 
 // MARK: - UITextFieldDelegate
 extension TemplateContentHeaderView: UITextFieldDelegate {
     
+    /// return 눌렸을 때 키보드 자동으로 내려가게끔 해줌.
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -39,6 +39,7 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
     // MARK: - Initialization
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
+        worryTitleTextField.becomeFirstResponder()
         setLayout()
         worryTitleTextField.delegate = self
     }
@@ -75,7 +76,7 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
 extension TemplateContentHeaderView: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.becomeFirstResponder()
+        textField.resignFirstResponder()
         return true
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -12,7 +12,7 @@ import Then
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
     
     // MARK: - Properties
-    private let worryTitleTextField = UITextField().then{
+    let worryTitleTextField = UITextField().then{
         $0.layer.cornerRadius = 8
         $0.backgroundColor = .clear
         $0.textColor = .kWhite
@@ -39,7 +39,6 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
     // MARK: - Initialization
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        worryTitleTextField.becomeFirstResponder()
         setLayout()
         worryTitleTextField.delegate = self
     }
@@ -69,6 +68,11 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1.adjustedW)
         }
+    }
+    
+    func resignTextField() {
+//        worryTitleTextField.resignFirstResponder()
+        worryTitleTextField.becomeFirstResponder()
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -10,7 +10,7 @@ import Combine
 import SnapKit
 import Then
 
-class TemplateContentTV: UIView {
+class TemplateContentTV: UITableView {
     
     // MARK: - View Model
     private let templateContentVM = TemplateContentViewModel()
@@ -18,28 +18,19 @@ class TemplateContentTV: UIView {
     private let input = PassthroughSubject<Int, Never>.init()
     
     // MARK: - Properties
-    private let templateId: Int
+    private var templateId: Int = 0
     private var questions: [String] = []
     private var hints: [String] = []
+    private var topConstraint: Constraint?
     
-    private lazy var templateContentTV = UITableView(frame: .zero, style: .grouped).then {
-        $0.backgroundColor = .kGray1
-        $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.separatorStyle = .none
-        $0.showsVerticalScrollIndicator = false
-        $0.delegate = self
-        $0.dataSource = self
-    }
-
     // MARK: - Life Cycle
-    init(templateId: Int) {
-        self.templateId = templateId
-        super.init(frame: .zero)
-        setLayout()
-        dataBind()
+    init() {
+        super.init(frame: .zero, style: .grouped)
         registerTV()
+        setTV()
+        setUI()
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -64,18 +55,22 @@ class TemplateContentTV: UIView {
         print(hints)
     }
     
-    private func setLayout() {
-        self.addSubview(templateContentTV)
-        templateContentTV.snp.makeConstraints{
-            $0.edges.equalToSuperview()
-        }
+    private func registerTV() {
+        self.register(TemplateContentTVC.self,
+                      forCellReuseIdentifier: TemplateContentTVC.classIdentifier)
+        self.register(TemplateContentHeaderView.self, forHeaderFooterViewReuseIdentifier: TemplateContentHeaderView.className)
+        self.estimatedSectionHeaderHeight = 110.adjustedH
     }
     
-    private func registerTV() {
-        templateContentTV.register(TemplateContentTVC.self,
-                                forCellReuseIdentifier: TemplateContentTVC.classIdentifier)
-        templateContentTV.register(TemplateContentHeaderView.self, forHeaderFooterViewReuseIdentifier: TemplateContentHeaderView.className)
-        templateContentTV.estimatedSectionHeaderHeight = 110.adjustedH
+    private func setUI() {
+        self.backgroundColor = .kGray1
+        self.separatorStyle = .none
+        self.showsVerticalScrollIndicator = false
+    }
+    
+    private func setTV() {
+        self.delegate = self
+        self.dataSource = self
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -72,10 +72,11 @@ extension TemplateContentTV : UITableViewDataSource
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
-        /// headerCell을 tableView가 reload될 때 같이 될 수 있게끔 해줌.
+        /// dispatchqueue로 해결해보려 했지만, 가려진 테이블 뷰가 불러올 때 계속 이게 실행되서 텍스트 필드로 커서가 올라가는 문제 발생
 //        DispatchQueue.main.async {
 //            headerCell.worryTitleTextField.becomeFirstResponder()
 //        }
+        headerCell.worryTitleTextField.becomeFirstResponder()
         return headerCell
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -12,16 +12,10 @@ import Then
 
 class TemplateContentTV: UITableView {
     
-    // MARK: - View Model
-    private let templateContentVM = TemplateContentViewModel()
-    private var cancellables = Set<AnyCancellable>()
-    private let input = PassthroughSubject<Int, Never>.init()
-    
     // MARK: - Properties
-    private var templateId: Int = 0
-    private var questions: [String] = []
-    private var hints: [String] = []
-    private var topConstraint: Constraint?
+    var templateId: Int = 0
+    var questions: [String] = []
+    var hints: [String] = []
     
     // MARK: - Life Cycle
     init() {
@@ -36,25 +30,6 @@ class TemplateContentTV: UITableView {
     }
     
     // MARK: - Functions
-    private func dataBind() {
-        let output = templateContentVM.transform(
-            input: TemplateContentViewModel.Input(input)
-        )
-        output.receive(on: DispatchQueue.main)
-            .sink { [weak self] templateContents in
-                self?.updateUI( templateContents)
-            }.store(in: &cancellables)
-        /// input 전달
-        input.send(templateId)
-    }
-    
-    private func updateUI(_ templateContents: TemplateContentModel) {
-        self.questions = templateContents.questions
-        self.hints = templateContents.hints
-        print(questions)
-        print(hints)
-    }
-    
     private func registerTV() {
         self.register(TemplateContentTVC.self,
                       forCellReuseIdentifier: TemplateContentTVC.classIdentifier)
@@ -81,7 +56,7 @@ extension TemplateContentTV: UITableViewDelegate {
         /// 헤더의 높이 + 헤더와 첫번째 셀간의 간격
         return 74.adjustedH + 36.adjustedH
     }
-
+    
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         /// expand 된 cell의 높이에 맞게 자동으로 변경해주기 위함
         return UITableView.automaticDimension
@@ -97,7 +72,10 @@ extension TemplateContentTV : UITableViewDataSource
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
-        
+        /// headerCell을 tableView가 reload될 때 같이 될 수 있게끔 해줌.
+//        DispatchQueue.main.async {
+//            headerCell.worryTitleTextField.becomeFirstResponder()
+//        }
         return headerCell
     }
     
@@ -106,7 +84,7 @@ extension TemplateContentTV : UITableViewDataSource
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TemplateContentTVC.classIdentifier, for: indexPath) as? TemplateContentTVC else {return UITableViewCell()}
         
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row])
-
+        
         return cell
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -72,10 +72,6 @@ extension TemplateContentTV : UITableViewDataSource
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
-        /// dispatchqueue로 해결해보려 했지만, 가려진 테이블 뷰가 불러올 때 계속 이게 실행되서 텍스트 필드로 커서가 올라가는 문제 발생
-//        DispatchQueue.main.async {
-//            headerCell.worryTitleTextField.becomeFirstResponder()
-//        }
         headerCell.worryTitleTextField.becomeFirstResponder()
         return headerCell
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -21,6 +21,8 @@ class TemplateContentTVC: UITableViewCell {
         $0.backgroundColor = .clear
     }
     
+    private let textViewConstant: CGFloat = 111.adjustedH
+    
     var placeHolder: String = ""
     
     lazy var textView = UITextView().then {
@@ -79,18 +81,16 @@ extension TemplateContentTVC: UITextViewDelegate {
         
         /// width를 self.frame.width로 지정하였더니, 텍스트뷰가 바로바로 업데이트되지 않는 문제 발생
         let size = CGSize(width: textView.bounds.width, height: .infinity)
-        let estimatedSize = textView.sizeThatFits(size)
-        print("textView 높이: ", estimatedSize.height)
-        
+        let estimatedSize = textView.sizeThatFits(size)        
         
         /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 고정 높이 반영
         textView.constraints.forEach { (constraint) in
             if constraint.firstAttribute == .height {
-                if estimatedSize.height > 111.adjustedH {
+                if estimatedSize.height > textViewConstant {
                     constraint.constant = estimatedSize.height
                 }
                 else {
-                    constraint.constant = 111.adjustedH
+                    constraint.constant = textViewConstant
                 }
             }
         }
@@ -102,20 +102,20 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
-        scrollToCursorPositionIfBelowKeyboard()
+//        scrollToCursorPositionIfBelowKeyboard()
     }
     
     /// textViewDidChange에서 textViewCell의 높이에 맞게 커서 위치를 자동으로 조절해주기
-    private func scrollToCursorPositionIfBelowKeyboard() {
-        print("텍스트뷰 높이", textView.bounds.size.height, "키보드 높이", keyboardHeight)
-        
-        /// 키보드에 커서가 가리지 않게끔 커서 위치 조정해주기
-        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height, width: textView.bounds.size.width, height: 0)
-        print("텍스트 뷰 프레임", textViewFrame)
-        textView.inputView?.frame = textViewFrame
-        /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요(즉각 업데이트 위함인듯)
-        textView.reloadInputViews()
-    }
+//    private func scrollToCursorPositionIfBelowKeyboard() {
+//        print("텍스트뷰 높이", textView.bounds.size.height, "키보드 높이", keyboardHeight)
+//
+//        /// 키보드에 커서가 가리지 않게끔 커서 위치 조정해주기
+//        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height - 50, width: textView.bounds.size.width, height: 0)
+//        print("텍스트 뷰 프레임", textViewFrame)
+//        textView.inputView?.frame = textViewFrame
+//        /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요(즉각 업데이트 위함인듯)
+//        textView.reloadInputViews()
+//    }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.textColor == .kGray4 {
@@ -138,11 +138,11 @@ extension TemplateContentTVC: UITextViewDelegate {
         /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 고정 높이 반영
         textView.constraints.forEach { (constraint) in
             if constraint.firstAttribute == .height {
-                if estimatedSize.height > 111.adjustedH {
+                if estimatedSize.height > textViewConstant {
                     constraint.constant = estimatedSize.height
                 }
                 else {
-                    constraint.constant = 111.adjustedH
+                    constraint.constant = textViewConstant
                 }
             }
         }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -57,7 +57,7 @@ class TemplateContentTVC: UITableViewCell {
         textView.snp.makeConstraints {
             $0.top.equalTo(questionLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(111)
+            $0.height.equalTo(111.adjustedH)
             $0.bottom.equalToSuperview().offset(-54)
         }
     }
@@ -77,16 +77,11 @@ extension TemplateContentTVC: UITextViewDelegate {
         let size = CGSize(width: self.frame.width, height: .infinity)
         let estimatedSize = textView.sizeThatFits(size)
         
+        /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 return 으로 함수 통과
+        guard estimatedSize.height > 111.adjustedH else { return }
         textView.constraints.forEach { (constraint) in
-            
-            /// 111 이하일때는 더 이상 줄어들지 않게하기
-            if estimatedSize.height <= 111 {
-                
-            }
-            else {
-                if constraint.firstAttribute == .height {
-                    constraint.constant = estimatedSize.height
-                }
+            if constraint.firstAttribute == .height {
+                constraint.constant = estimatedSize.height
             }
         }
         
@@ -102,7 +97,7 @@ extension TemplateContentTVC: UITextViewDelegate {
             textView.textColor = .kWhite
         }
     }
-
+    
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty == true {
             textView.text = placeHolder

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -11,6 +11,8 @@ import Then
 
 class TemplateContentTVC: UITableViewCell {
     
+    private var keyboardHeight: CGFloat = 336.adjustedH
+    
     private var questionLabel = UILabel().then {
         $0.text = "질문지 제목"
         $0.font = .kB1B16
@@ -85,11 +87,27 @@ extension TemplateContentTVC: UITextViewDelegate {
                 constraint.constant = estimatedSize.height
             }
         }
-        
+                
+        /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요
+        self.layoutIfNeeded()
+
         if let tableView = superview as? UITableView {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
+        scrollToCursorPositionIfBelowKeyboard()
+    }
+    
+    /// textViewDidChange에서 textViewCell의 높이에 맞게 커서 위치를 자동으로 조절해주기
+    private func scrollToCursorPositionIfBelowKeyboard() {
+        print("텍스트뷰 높이", textView.bounds.size.height, "키보드 높이", keyboardHeight)
+        
+        /// 키보드에 커서가 가리지 않게끔 커서 위치 조정해주기
+        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height - keyboardHeight, width: textView.bounds.size.width, height: keyboardHeight)
+        print("텍스트 뷰 프레임", textViewFrame)
+        textView.inputView?.frame = textViewFrame
+        /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요(즉각 업데이트 위함인듯)
+        textView.reloadInputViews()
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -74,7 +74,8 @@ extension TemplateContentTVC: UITextViewDelegate {
     // MARK: textview 높이 자동조절
     func textViewDidChange(_ textView: UITextView) {
         
-        let size = CGSize(width: self.frame.width, height: .infinity)
+        /// width를 self.frame.width로 지정하였더니, 텍스트뷰가 바로바로 업데이트되지 않는 문제 발생
+        let size = CGSize(width: textView.bounds.width, height: .infinity)
         let estimatedSize = textView.sizeThatFits(size)
         
         /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 return 으로 함수 통과

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -11,6 +11,7 @@ import Then
 
 class TemplateContentTVC: UITableViewCell {
     
+    // MARK: - Properties
     private var keyboardHeight: CGFloat = 336.adjustedH
     
     private var questionLabel = UILabel().then {

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -80,18 +80,24 @@ extension TemplateContentTVC: UITextViewDelegate {
         /// width를 self.frame.width로 지정하였더니, 텍스트뷰가 바로바로 업데이트되지 않는 문제 발생
         let size = CGSize(width: textView.bounds.width, height: .infinity)
         let estimatedSize = textView.sizeThatFits(size)
+        print("textView 높이: ", estimatedSize.height)
         
-        /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 return 으로 함수 통과
-        guard estimatedSize.height > 111.adjustedH else { return }
+        
+        /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 고정 높이 반영
         textView.constraints.forEach { (constraint) in
             if constraint.firstAttribute == .height {
-                constraint.constant = estimatedSize.height
+                if estimatedSize.height > 111.adjustedH {
+                    constraint.constant = estimatedSize.height
+                }
+                else {
+                    constraint.constant = 111.adjustedH
+                }
             }
         }
-                
+        
         /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요
         self.layoutIfNeeded()
-
+        
         if let tableView = superview as? UITableView {
             tableView.beginUpdates()
             tableView.endUpdates()
@@ -104,7 +110,7 @@ extension TemplateContentTVC: UITextViewDelegate {
         print("텍스트뷰 높이", textView.bounds.size.height, "키보드 높이", keyboardHeight)
         
         /// 키보드에 커서가 가리지 않게끔 커서 위치 조정해주기
-        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height - keyboardHeight, width: textView.bounds.size.width, height: keyboardHeight)
+        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height, width: textView.bounds.size.width, height: 0)
         print("텍스트 뷰 프레임", textViewFrame)
         textView.inputView?.frame = textViewFrame
         /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요(즉각 업데이트 위함인듯)
@@ -119,10 +125,31 @@ extension TemplateContentTVC: UITextViewDelegate {
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.isEmpty == true {
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedText.isEmpty == true {
             textView.text = placeHolder
             textView.textColor = .kGray4
         }
+        
+        let size = CGSize(width: textView.bounds.width, height: .infinity)
+        let estimatedSize = textView.sizeThatFits(size)
+        
+        /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 고정 높이 반영
+        textView.constraints.forEach { (constraint) in
+            if constraint.firstAttribute == .height {
+                if estimatedSize.height > 111.adjustedH {
+                    constraint.constant = estimatedSize.height
+                }
+                else {
+                    constraint.constant = 111.adjustedH
+                }
+            }
+        }
+
+        if let tableView = superview as? UITableView {
+            tableView.beginUpdates()
+            tableView.endUpdates()
+        }
     }
 }
-

--- a/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
@@ -83,9 +83,7 @@ extension WriteModalVC {
     
     /// 뷰모델의 데이터를 뷰컨의 리스트 데이터와 연동
     fileprivate func setBindings() {
-        print("ViewController - setBindings()")
         self.templateVM.templateListPublisher.sink{ (updatedList : [TemplateListPublisherModel]) in
-            print("ViewController - updatedList.count: \(updatedList.count)")
             self.templateList = updatedList
         }.store(in: &disposalbleBag)
     }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -281,9 +281,8 @@ extension WriteVC {
         if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardHeight = keyboardFrame.cgRectValue.height
             
-            let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardHeight , right: 0.0)
+            let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardHeight + 50, right: 0.0)
             templateContentTV.contentInset = contentInsets
-            templateContentTV.scrollIndicatorInsets = contentInsets
         }
     }
     
@@ -292,6 +291,5 @@ extension WriteVC {
         let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
         
         templateContentTV.contentInset = contentInsets
-        templateContentTV.scrollIndicatorInsets = contentInsets
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -10,7 +10,7 @@ import Combine
 import SnapKit
 import Then
 
-class WriteVC: UIViewController {
+class WriteVC: BaseVC {
     
     // MARK: - Properties
     private let writeModalVC = WriteModalVC()
@@ -92,7 +92,8 @@ class WriteVC: UIViewController {
         setNaviButtonAction()
         setLayout()
         pressBtn()
-        setObserver()
+        hideKeyboardWhenTappedAround()
+        addKeyboardObserver()
     }
     
     // MARK: - Functions
@@ -100,15 +101,6 @@ class WriteVC: UIViewController {
         DispatchQueue.main.async { [self] in
             self.dismiss(animated: true)
         }
-    }
-    
-    private func setObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.didCompleteWritingNotification(_:)),
-            name: NSNotification.Name("CompleteWriting"),
-            object: nil
-        )
     }
     
     private func setNaviButtonAction() {
@@ -223,8 +215,61 @@ extension WriteVC: TemplateTitleDelegate {
             $0.top.equalTo(self.dividingLine.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
+// MARK: - Keyboard
+extension WriteVC {
+    
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.keyboardWillAppear(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(keyboardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+    }
+    
+    private func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    @objc
+    func keyboardWillAppear(_ notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardHeight = keyboardFrame.cgRectValue.height
+            // 키보드 높이만큼 tableView가 위로 올라감.
+//            UIView.animate(withDuration: 0.3) {
+//                self.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+//            }
+            templateContentTV.setContentOffset(CGPoint(x: 0, y: keyboardHeight), animated: true)
+
+        }
+    }
+    @objc
+    func keyboardWillDisappear(_ notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardHeight = keyboardFrame.cgRectValue.height
+            // 키보드 높이만큼 tableView가 아래로 다시 내려감
+//            UIView.animate(withDuration: 0.3) {
+//                self.transform = CGAffineTransform.identity
+//            }
+            templateContentTV.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
         }
     }
 }
+
 
 

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -276,21 +276,22 @@ extension WriteVC {
         )
     }
     
+    /// 키보드 높이가 올라올 때, contentInset을 키보드 높이만큼 조정해줌.
     @objc func keyboardWillAppear(_ notification: NSNotification) {
         if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardHeight = keyboardFrame.cgRectValue.height
             
-            let contentInsets = UIEdgeInsets(top: 80, left: 0.0, bottom: keyboardHeight , right: 0.0)
-            templateContentTV.contentInset = contentInsets
-//            templateContentTV.scrollIndicatorInsets = contentInsets
-            }
-        }
-        
-        @objc func keyboardWillDisappear(_ notification: NSNotification) {
-            let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
-            
-            // reset back the content inset to zero after keyboard is gone
+            let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardHeight , right: 0.0)
             templateContentTV.contentInset = contentInsets
             templateContentTV.scrollIndicatorInsets = contentInsets
         }
     }
+    
+    /// 키보드 내려갈 떄, 다시 원래대로 복귀
+    @objc func keyboardWillDisappear(_ notification: NSNotification) {
+        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
+        
+        templateContentTV.contentInset = contentInsets
+        templateContentTV.scrollIndicatorInsets = contentInsets
+    }
+}

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -118,7 +118,6 @@ class WriteVC: BaseVC {
     private func updateUI(_ templateContents: TemplateContentModel) {
         templateContentTV.questions = templateContents.questions
         templateContentTV.hints = templateContents.hints
-        print(templateContentTV.questions)
         
         view.addSubview(templateContentTV)
         templateContentTV.snp.updateConstraints {


### PR DESCRIPTION
## 💪 작업한 내용
- BaseVC를 상속 받고 hideKeyboardWhenTappedAround() 함수를 사용하여 고민 작성뷰에서 화면 터치 시에 키보드가 자동으로 내려가게끔 하였습니다. 
- 첫번째 고민 카테고리를 선택 시에 textField가 becomeFirstResponder가 되게끔 하여 커서 위치가 textField에 가게끔 하고, 키보드가 올라오게 하였습니다. 
- 키보드가 올라올 때 contentInset을 조정해주어서 화면을 키보드가 가리지 않게끔 하였습니다. (keyboardWillAppear)
- 테이블뷰 Cell이 expand될 때 커서가 키보드에 가려지는 것을 방지하기 위해 scrollToCursorPositionIfBelowKeyboard() 메서드를 추가하였습니다. 
- 텍스트 뷰의 텍스트 및 공백을 모두 지울 때 텍스트 뷰가 즉시 축소될 수 있게 분기처리를 다시 해주었습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- textView가 글자에 맞춰서 자동으로 줄바꿈이 되고, tableViewCell이 expand되주게끔 할 때 
  let size = CGSize(width: `self.frame.width`, height: .infinity) 로 size를 하니 텍스트뷰가 자연스럽게 업데이트 되지 않았습니다. 
  코드를 let size = CGSize(width: `textView.bounds.width`, height: .infinity)와 같이 수정하였더니, sizeThatFits함수가 텍스트 뷰의
  width를 잘 인식하여 줄바꿈이 잘 되는 모습을 확인할 수 있었습니다. 

### 🛠️ 개선해야할 점
1. 첫번째 카테고리 선택 후 고민작성할 때 뿐만 아니라 카테고리를 변경하더라도 텍스트필드에 커서가 올 수 있게끔 수정이 필요합니다. 
2. tableView에서 위쪽 Cell에서 아래쪽 Cell의 textView를 클릭하면 화면이동이 잘 되지만, 아래쪽 Cell에서 위쪽 Cell을 클릭했을 시에 화면 이동이 잘 되지 않아 글자가 잘려보이는 현상에 대해 수정이 필요합니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
https://github.com/TeamHARA/KAERA_iOS/assets/45239582/2a96c1ad-8ff6-49d8-90a3-#31 7c892e8d2


## 🚨 관련 이슈
- Resolved: #31


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
