### PR TITLE
[Feat] 템플릿 종류 조회하기 API 연결

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		85EBC7F72A5AD95D00B9E891 /* ArchiveVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F62A5AD95D00B9E891 /* ArchiveVC.swift */; };
 		85ECEE472A9A117E00A624AE /* ArchiveAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECEE462A9A117E00A624AE /* ArchiveAPI.swift */; };
 		85ECEE492A9A406B00A624AE /* ArchiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECEE482A9A406B00A624AE /* ArchiveService.swift */; };
+		85ECEE4B2A9B815E00A624AE /* WriteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECEE4A2A9B815E00A624AE /* WriteService.swift */; };
+		85ECEE4D2A9B821500A624AE /* WriteAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECEE4C2A9B821500A624AE /* WriteAPI.swift */; };
 		E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA02A90959A006B2E74 /* HomeService.swift */; };
 		E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA22A909829006B2E74 /* HomeAPI.swift */; };
 		E721EABD2A51D5D900A04AA0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E721EABC2A51D5D900A04AA0 /* Then */; };
@@ -114,6 +116,8 @@
 		85EBC7F62A5AD95D00B9E891 /* ArchiveVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveVC.swift; sourceTree = "<group>"; };
 		85ECEE462A9A117E00A624AE /* ArchiveAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAPI.swift; sourceTree = "<group>"; };
 		85ECEE482A9A406B00A624AE /* ArchiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveService.swift; sourceTree = "<group>"; };
+		85ECEE4A2A9B815E00A624AE /* WriteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteService.swift; sourceTree = "<group>"; };
+		85ECEE4C2A9B821500A624AE /* WriteAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAPI.swift; sourceTree = "<group>"; };
 		E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		E70C7CA02A90959A006B2E74 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		E70C7CA22A909829006B2E74 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
@@ -406,6 +410,7 @@
 			children = (
 				E70C7CA22A909829006B2E74 /* HomeAPI.swift */,
 				85ECEE462A9A117E00A624AE /* ArchiveAPI.swift */,
+				85ECEE4C2A9B821500A624AE /* WriteAPI.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -415,6 +420,7 @@
 			children = (
 				E70C7CA02A90959A006B2E74 /* HomeService.swift */,
 				85ECEE482A9A406B00A624AE /* ArchiveService.swift */,
+				85ECEE4A2A9B815E00A624AE /* WriteService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -654,6 +660,7 @@
 				E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */,
 				E79AAC3D2A52F2C300F3F439 /* UIFont+.swift in Sources */,
 				85887D8E2A5D086300F7FB21 /* TemplateViewModel.swift in Sources */,
+				85ECEE4D2A9B821500A624AE /* WriteAPI.swift in Sources */,
 				E7BB4F492A5EF7320018312B /* HomeGemListModel.swift in Sources */,
 				E7BB4F512A5EF8260018312B /* WorryListModel.swift in Sources */,
 				E79AAC392A52F2C300F3F439 /* UICollectionVIew+.swift in Sources */,
@@ -687,6 +694,7 @@
 				E7BB4F472A5EF7060018312B /* HomeGemListViewModel.swift in Sources */,
 				E7C808E92A4D37F800F475CE /* AppDelegate.swift in Sources */,
 				E73CA3DC2A693C9D00BAC9D6 /* GemStoneEmptyView.swift in Sources */,
+				85ECEE4B2A9B815E00A624AE /* WriteService.swift in Sources */,
 				E7FEC0982A6D1274006F36BF /* HomeWorryDetailViewModel.swift in Sources */,
 				85887D842A5C42A700F7FB21 /* WriteModalCVC.swift in Sources */,
 				85A8492F2A87A9EC009F1468 /* TemplateContentTV.swift in Sources */,

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -16,22 +16,22 @@ final class WriteAPI {
     
     private init() { }
     
-    public private(set) var archiveWorryListResponse: GeneralResponse<WorryListModel>?
+    public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?
     
     
     // MARK: - HomeGemList
-    func getArchiveWorryList(param: Int, completion: @escaping (GeneralResponse<WorryListModel>?) -> () ) {
-        archiveProvider.request(.archiveWorryList(templateId: param)) { [weak self] response in
+    func getTemplateList(completion: @escaping (GeneralArrayResponse<TemplateListModel>?) -> () ) {
+        archiveProvider.request(.getTemplateList) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
-                    self?.archiveWorryListResponse = try
-                    result.map(GeneralResponse<WorryListModel>?.self)
+                    self?.templateListResponse = try
+                    result.map(GeneralArrayResponse<TemplateListModel>?.self)
                     print("성공")
                     print(result)
-                    guard let worryList = self?.archiveWorryListResponse else { return }
-                    print(worryList)
-                    completion(worryList)
+                    guard let templateList = self?.templateListResponse else { return }
+                    print(templateList)
+                    completion(templateList)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -1,0 +1,46 @@
+//
+//  WriteAPI.swift
+//  KAERA
+//
+//  Created by saint on 2023/08/27.
+//
+
+
+import Foundation
+import Moya
+
+final class WriteAPI {
+    
+    static let shared: WriteAPI = WriteAPI()
+    private let archiveProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
+    
+    private init() { }
+    
+    public private(set) var archiveWorryListResponse: GeneralResponse<WorryListModel>?
+    
+    
+    // MARK: - HomeGemList
+    func getArchiveWorryList(param: Int, completion: @escaping (GeneralResponse<WorryListModel>?) -> () ) {
+        archiveProvider.request(.archiveWorryList(templateId: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.archiveWorryListResponse = try
+                    result.map(GeneralResponse<WorryListModel>?.self)
+                    print("성공")
+                    print(result)
+                    guard let worryList = self?.archiveWorryListResponse else { return }
+                    print(worryList)
+                    completion(worryList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+}
+

--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -20,4 +20,5 @@ struct APIConstant {
     
     static let homeWorryList = "/worry/list"
     static let archiveWorryList = "/worry"
+    static let templateList = "/template"
 }

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -1,0 +1,45 @@
+//
+//  WriteServices.swift
+//  KAERA
+//
+//  Created by saint on 2023/08/27.
+//
+
+import Foundation
+import Moya
+
+enum WriteService {
+    case getTemplateList
+}
+
+extension WriteService: BaseTargetType {
+    
+    var path: String {
+        switch self {
+        case .getTemplateList:
+            return APIConstant.templateList
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getTemplateList:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .getTemplateList:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String : String]? {
+        switch self {
+        case .getTemplateList:
+            return NetworkConstant.hasTokenHeader
+        }
+    }
+}
+

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
@@ -9,10 +9,10 @@ import UIKit
 import Foundation
 
 /// 서버통신용 모델
-struct TemplateListModel {
+struct TemplateListModel: Codable {
     let templateId: Int
-    let templateTitle: String
-    let templateDetail: String
+    let title: String
+    let shortInfo: String
     let info: String
     let hasUsed: Bool
 }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalVC.swift
@@ -87,6 +87,8 @@ extension ArchiveModalVC {
     fileprivate func setBindings() {
         self.templateVM.templateListPublisher.sink{ [weak self] (updatedList : [TemplateListPublisherModel]) in
             self?.templateList = updatedList
+            let showEveryJewels = TemplateListPublisherModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", image: UIImage())
+            self?.templateList.insert(showEveryJewels, at:0)
         }.store(in: &disposalbleBag)
     }
 }
@@ -107,7 +109,6 @@ extension ArchiveModalVC: UICollectionViewDelegateFlowLayout {
     
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("click index=\(indexPath.row)")
         
         // 기존의 선택되었던 Cell의 디자인을 초기화한다.
         if let previousCell = collectionView.cellForItem(at: IndexPath(row: templateIndex, section: 0)) as? ArchiveModalCVC {
@@ -139,6 +140,12 @@ extension ArchiveModalVC: UICollectionViewDataSource {
             withReuseIdentifier: ArchiveModalCVC.className, for: indexPath)
                 as? ArchiveModalCVC else { return UICollectionViewCell() }
         cell.dataBind(model: templateList[indexPath.item], indexPath: indexPath)
+        
+        if let cell = collectionView.cellForItem(at: IndexPath(row: templateIndex, section: 0)) as? ArchiveModalCVC {
+            cell.templateCell.layer.borderColor = UIColor.kYellow1.cgColor
+            cell.checkIcon.isHidden = false
+        }
+        
         return cell
     }
 }

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -12,7 +12,7 @@ import Combine
 class WorryListViewModel: ViewModelType {
     
     // MARK: - Properties
-    private var IdtoImgDict: [Int: String] = [1: "gem_pink_m", 2: "gem_orange_m", 3: "gem_blue_m", 4: "gem_green_m", 5: "gem_yellow_m", 6: "gem_red_m"]
+    private var IdtoImgDict: [Int: String] = [1: "gem_blue_m", 2: "gem_red_m", 3: "gem_orange_m", 4: "gem_green_m", 5: "gem_pink_m", 6: "gem_yellow_m"]
     
     private var worryUpdateList: [WorryListPublisherModel] = []
     

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -18,33 +18,26 @@ class TemplateViewModel: ViewModelType {
     
     /// 딕셔너리는 hashable 프로토콜을 따라야 하므로, 1대1 매칭을 위해 커스텀 구조체 사용
     let idToImgTuple: [customKey: String] = [
-        customKey(index: 0, hasUsed: true): "gem_pink_s_on",
-        customKey(index: 0, hasUsed: false): "gem_pink_s_off",
-        customKey(index: 1, hasUsed: true): "gem_pink_s_on",
-        customKey(index: 1, hasUsed: false): "gem_pink_s_off",
-        customKey(index: 2, hasUsed: true): "gem_orange_s_on",
-        customKey(index: 2, hasUsed: false): "gem_orange_s_off",
-        customKey(index: 3, hasUsed: true): "gem_blue_s_on",
-        customKey(index: 3, hasUsed: false): "gem_blue_s_off",
+        customKey(index: 1, hasUsed: true): "gem_blue_s_on",
+        customKey(index: 1, hasUsed: false): "gem_blue_s_off",
+        customKey(index: 2, hasUsed: true): "gem_red_s_on",
+        customKey(index: 2, hasUsed: false): "gem_red_s_off",
+        customKey(index: 3, hasUsed: true): "gem_orange_s_on",
+        customKey(index: 3, hasUsed: false): "gem_orange_s_off",
         customKey(index: 4, hasUsed: true): "gem_green_s_on",
         customKey(index: 4, hasUsed: false): "gem_green_s_off",
-        customKey(index: 5, hasUsed: true): "gem_yellow_s_on",
-        customKey(index: 5, hasUsed: false): "gem_yellow_s_off"
-    ]
-    
-    var templateListDummy = [
-        TemplateListModel(templateId: 0, templateTitle: "모든 보석 보기", templateDetail: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
-        TemplateListModel(templateId: 1, templateTitle: "Free Flow", templateDetail: "빈 공간을 자유롭게 채우기", info: "내가 할 수 있는 선택지를 나열해보세요. 각각 어떤 장점과 단점을 가지고 있나요? 당신의 가능성을 펼쳐 비교해 더 나은 선택을 할 수 있도록 도와줄게요.", hasUsed: true),
-        TemplateListModel(templateId: 2, templateTitle: "장단점 생각하기", templateDetail: "할까? 말까? 최고의 선택을 돕는 해결사", info: "문제의 근본적인 이유를 찾아주는 3why 기법이에요. 왜?, 그래서 왜?, 그리고 왜? 숨어있는 원인을 캐내 문제를 해결할 수 있어요.", hasUsed: true),
-        TemplateListModel(templateId: 3, templateTitle: "다섯번의 왜?", templateDetail: "5why 기법을 활용한 물음표 곱씹기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: true),
-        TemplateListModel(templateId: 4, templateTitle: "자기관리론", templateDetail: "데일카네기가 제시한 걱정 극복 글쓰기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 5, templateTitle: "단 하나의 목표", templateDetail: "One thing, 우선순위 정하기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 6, templateTitle: "땡스투 새겨보기", templateDetail: "긍정적인 힘을 만드는 감사 일기", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 7, templateTitle: "10-10-10", templateDetail: "수지 웰치의 좋은 결정을 내리는 간단한 방법", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false),
-        TemplateListModel(templateId: 8, templateTitle: "실행력 키우기", templateDetail: "move! move! 일단 움직여, 실행론", info: "집중해야할 단 한가지 목표를 정해보세요. 삶의 우선순위를 설계하고, 지금 집중해야 할 일은 무엇인지 찾아낼 수 있어요.", hasUsed: false)
+        customKey(index: 5, hasUsed: true): "gem_pink_s_on",
+        customKey(index: 5, hasUsed: false): "gem_pink_s_off",
+        customKey(index: 6, hasUsed: true): "gem_yellow_s_on",
+        customKey(index: 6, hasUsed: false): "gem_yellow_s_off"
     ]
     
     var templateUpdateList: [TemplateListPublisherModel] = []
+    
+    var templateListDummy = [
+           TemplateListModel(templateId: 0, title: "모든 보석 보기", shortInfo: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
+           TemplateListModel(templateId: 1, title: "Free Flow", shortInfo: "빈 공간을 자유롭게 채우기", info: "내가 할 수 있는 선택지를 나열해보세요. 각각 어떤 장점과 단점을 가지고 있나요? 당신의 가능성을 펼쳐 비교해 더 나은 선택을 할 수 있도록 도와줄게요.", hasUsed: true)
+       ]
     
     lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
     
@@ -74,16 +67,21 @@ class TemplateViewModel: ViewModelType {
 // MARK: - Functions
 extension TemplateViewModel {
     private func convertIdtoImg() {
-        templateListDummy.forEach {
-            guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return }
-            templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, templateDetail: $0.templateDetail, image: UIImage(named: imgName) ?? UIImage() ))
+        WriteAPI.shared.getTemplateList { result in
+            guard let result = result, let data = result.data else { return }
+            print("템플릿 리스트입니다", data)
+
+            data.forEach {
+                guard let imgName = self.idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return }
+                self.templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.title, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
+            }
         }
     }
     private func convertTemplateInfo() {
         templateInfoList = []
         templateListDummy.forEach {
             guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-            self.templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.templateTitle, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
+            self.templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.title, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
         }
         self.output.send(templateInfoList)
     }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -69,7 +69,6 @@ extension TemplateViewModel {
     private func convertIdtoImg() {
         WriteAPI.shared.getTemplateList { result in
             guard let result = result, let data = result.data else { return }
-            print("템플릿 리스트입니다", data)
 
             data.forEach {
                 guard let imgName = self.idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -102,20 +102,7 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
-//        scrollToCursorPositionIfBelowKeyboard()
     }
-    
-    /// textViewDidChange에서 textViewCell의 높이에 맞게 커서 위치를 자동으로 조절해주기
-//    private func scrollToCursorPositionIfBelowKeyboard() {
-//        print("텍스트뷰 높이", textView.bounds.size.height, "키보드 높이", keyboardHeight)
-//
-//        /// 키보드에 커서가 가리지 않게끔 커서 위치 조정해주기
-//        let textViewFrame = CGRect(x: 0, y: textView.bounds.size.height - 50, width: textView.bounds.size.width, height: 0)
-//        print("텍스트 뷰 프레임", textViewFrame)
-//        textView.inputView?.frame = textViewFrame
-//        /// 좀더 자연스로운 애니메이션 효과? 를 위해 필요(즉각 업데이트 위함인듯)
-//        textView.reloadInputViews()
-//    }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.textColor == .kGray4 {

--- a/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
@@ -19,7 +19,7 @@ class WriteModalVC: UIViewController {
     var templateVM: TemplateViewModel = TemplateViewModel()
     
     var templateList: [TemplateListPublisherModel] = []
-    var disposalbleBag = Set<AnyCancellable>()
+    var cancellable = Set<AnyCancellable>()
     
     weak var sendTitleDelegate: TemplateTitleDelegate?
     
@@ -85,7 +85,7 @@ extension WriteModalVC {
     fileprivate func setBindings() {
         self.templateVM.templateListPublisher.sink{ (updatedList : [TemplateListPublisherModel]) in
             self.templateList = updatedList
-        }.store(in: &disposalbleBag)
+        }.store(in: &cancellable)
     }
 }
 
@@ -123,7 +123,7 @@ extension WriteModalVC: UICollectionViewDelegateFlowLayout {
         
         /// 선택한 카테고리의 종류를 WriteVC로 보내줌으로써 화면에 선택된 템플릿이 무엇인지를 알려줍니다.
         /// '모든 보석 보기' cell은 포함하면 안되므로, 그 다음 셀의 제목을 첫번째 제목으로 하기 위해 +1을 해줍니다.
-        sendTitleDelegate?.templateReload(templateId: templateIndex, templateTitle: templateVM.templateListPublisher.value[templateIndex + 1].templateTitle, templateInfo: templateVM.templateListPublisher.value[templateIndex + 1].templateDetail)
+        sendTitleDelegate?.templateReload(templateId: templateIndex, templateTitle: templateVM.templateListPublisher.value[templateIndex].templateTitle, templateInfo: templateVM.templateListPublisher.value[templateIndex].templateDetail)
         
         // notification for tableView reload
         self.dismiss(animated: true, completion: nil)
@@ -134,7 +134,7 @@ extension WriteModalVC: UICollectionViewDelegateFlowLayout {
 extension WriteModalVC: UICollectionViewDataSource {
     /// '모든 보석 보기' cell은 제외해야 하기에 -1을 해줍니다.
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return templateList.count - 1
+        return templateList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -142,7 +142,7 @@ extension WriteModalVC: UICollectionViewDataSource {
             withReuseIdentifier: WriteModalCVC.className, for: indexPath)
                 as? WriteModalCVC else { return UICollectionViewCell() }
         /// '모든 보석 보기' cell은 포함하면 안되므로, 그 다음 셀의 제목을 첫번째 제목으로 하기 위해 +1을 해줍니다.
-        cell.dataBind(model: templateList[indexPath.item + 1], indexPath: indexPath)
+        cell.dataBind(model: templateList[indexPath.item], indexPath: indexPath)
         return cell
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
@@ -123,7 +123,7 @@ extension WriteModalVC: UICollectionViewDelegateFlowLayout {
         
         /// 선택한 카테고리의 종류를 WriteVC로 보내줌으로써 화면에 선택된 템플릿이 무엇인지를 알려줍니다.
         /// '모든 보석 보기' cell은 포함하면 안되므로, 그 다음 셀의 제목을 첫번째 제목으로 하기 위해 +1을 해줍니다.
-        sendTitleDelegate?.templateReload(templateId: templateIndex, templateTitle: templateVM.templateListPublisher.value[templateIndex].templateTitle, templateInfo: templateVM.templateListPublisher.value[templateIndex].templateDetail)
+        sendTitleDelegate?.templateReload(templateId: templateIndex, templateTitle: templateList[templateIndex].templateTitle, templateInfo: templateList[templateIndex].templateDetail)
         
         // notification for tableView reload
         self.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
## 💪 작업한 내용
- 템플릿 종류 조회하기 API를 연결하였습니다. 
- 고민작성뷰와 고민보관함 뷰에서 둘 다 동일한 ViewModel을 사용하는 기존의 구조를 사용했습니다. 
- 고민보관함 뷰에서는 '전체 고민 보기' 탭이 따로 있어야 하기 때문에 화면에 데이터를 뿌려주기 전에 배열의 0번째 index에 추가로 대입해주었습니다. 
- 고민보관함 뷰에서 '전체 고민 보기' 탭이 뷰가 띄어지는 시점에서 노란색으로 체크되어 있게끔 수정했습니다. 
- 보석 종류를 디자인에 맞게 변경하였습니다. (기존에 보석 순서가 잘못 매칭 되어있었습니다)


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 템플릿 종류를 조회하는 Modal뷰는 동기 방식이 아닌, 기존의 빈배열에 받아온 데이터를 append해주는 비동기 방식으로 구현하였습니다,,😐


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-08-28 at 14 39 20](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/6051af3a-57c0-4117-bd45-4fbe98b6bfa7)
<img width="839" alt="image" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/66d75f92-1828-4ccc-842c-bbe2ea0794c4">


## 🚨 관련 이슈
- Resolved: #38 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
