### PR TITLE
[Feat] 고민보관함탭 고민작성지뷰 템플릿 종류 조회하기 API 연결

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -51,6 +51,7 @@ class TemplateInfoVC: UIViewController {
         registerTV()
         resetCellStatus()
         setObserver()
+        input.send() /// 구독 후 ViewModel과 데이터를 연동
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -102,7 +103,6 @@ class TemplateInfoVC: UIViewController {
                 self?.updateTV(list)
             }
             .store(in: &cancellables)
-        input.send() /// 구독 후 ViewModel과 데이터를 연동
     }
     
     private func updateTV(_ list: [ TemplateInfoPublisherModel]) {

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -76,13 +76,18 @@ extension TemplateViewModel {
             }
         }
     }
+
     private func convertTemplateInfo() {
-        templateInfoList = []
-        templateListDummy.forEach {
-            guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-            self.templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.title, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
+        WriteAPI.shared.getTemplateList { result in
+            guard let result = result, let data = result.data else { return }
+
+            self.templateInfoList = data.compactMap { templateData in
+                guard let imgName = self.idToImgTuple[customKey(index: templateData.templateId, hasUsed: true)] else { return nil }
+                return TemplateInfoPublisherModel(templateId: templateData.templateId, templateTitle: templateData.title, info: templateData.info, image: UIImage(named: imgName) ?? UIImage())
+            }
+
+            self.output.send(self.templateInfoList)
         }
-        self.output.send(templateInfoList)
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
- 고민보관함탭의 고민작성지뷰와 템플릿 종류 조회하기 API를 연결합니다. 
- compactMap 함수를 사용하여 받아온 데이터를 templateInfoList에 담아서 templateInfoTableView로 보내주는 방식으로 구현했습니다.


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- https://velog.io/@un1945/Swift-%EA%B3%A0%EC%B0%A8%ED%95%A8%EC%88%98-compactMap-flatMap
- map 대신에 compactMap을 사용했는데, mapping과 더불어 옵셔널 바인딩을 자동으로 해주는 좋은 기능인 것 같아서 공유해봅니당! 추가로 flatMap에 대한 자료도 같이 나와있어요


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-08-28 at 15 17 14](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/80b75701-9a37-4ba5-9ed9-063c3f5fb5d1)
<img width="839" alt="image" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/e2fcdebd-5842-43db-bb49-85d187cf494e">

## 🚨 관련 이슈
- Resolved: #40 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
