### PR TITLE
[Feat] 고민작성뷰 템플릿별 질문 조회하기 API 연결

### DIFF
--- a/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
+++ b/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
@@ -26,10 +26,7 @@ final class ArchiveAPI {
                 do {
                     self?.archiveWorryListResponse = try
                     result.map(GeneralResponse<WorryListModel>?.self)
-                    print("성공")
-                    print(result)
                     guard let worryList = self?.archiveWorryListResponse else { return }
-                    print(worryList)
                     completion(worryList)
                 } catch(let err) {
                     print(err.localizedDescription)

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -26,10 +26,7 @@ final class HomeAPI {
                 do {
                     self?.homeGemListResponse = try
                     result.map(GeneralArrayResponse<HomeGemListModel>?.self)
-                    print("성공")
-                    print(result)
                     guard let gemList = self?.homeGemListResponse else { return }
-                    print(gemList)
                     completion(gemList)
                 } catch(let err) {
                     print(err.localizedDescription)

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -28,10 +28,7 @@ final class WriteAPI {
                 do {
                     self?.templateListResponse = try
                     result.map(GeneralArrayResponse<TemplateListModel>?.self)
-                    print("성공")
-                    print(result)
                     guard let templateList = self?.templateListResponse else { return }
-                    print(templateList)
                     completion(templateList)
                 } catch(let err) {
                     print(err.localizedDescription)
@@ -51,10 +48,7 @@ final class WriteAPI {
                 do {
                     self?.templateContentResponse = try
                     result.map(GeneralResponse<TemplateContentModel>?.self)
-                    print("성공")
-                    print(result)
                     guard let contentList = self?.templateContentResponse else { return }
-                    print(contentList)
                     completion(contentList)
                 } catch(let err) {
                     print(err.localizedDescription)

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -12,16 +12,17 @@ import Moya
 final class WriteAPI {
     
     static let shared: WriteAPI = WriteAPI()
-    private let archiveProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
+    private let writeProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     
     public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?
+    public private(set) var templateContentResponse: GeneralResponse<TemplateContentModel>?
     
     
     // MARK: - HomeGemList
     func getTemplateList(completion: @escaping (GeneralArrayResponse<TemplateListModel>?) -> () ) {
-        archiveProvider.request(.getTemplateList) { [weak self] response in
+        writeProvider.request(.getTemplateList) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
@@ -32,6 +33,29 @@ final class WriteAPI {
                     guard let templateList = self?.templateListResponse else { return }
                     print(templateList)
                     completion(templateList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func getTemplateQuestion(param: Int, completion: @escaping (GeneralResponse<TemplateContentModel>?) -> () ) {
+        writeProvider.request(.getTemplateQuestion(templateId: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.templateContentResponse = try
+                    result.map(GeneralResponse<TemplateContentModel>?.self)
+                    print("성공")
+                    print(result)
+                    guard let contentList = self?.templateContentResponse else { return }
+                    print(contentList)
+                    completion(contentList)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum WriteService {
     case getTemplateList
+    case getTemplateQuestion(templateId: Int)
 }
 
 extension WriteService: BaseTargetType {
@@ -18,19 +19,21 @@ extension WriteService: BaseTargetType {
         switch self {
         case .getTemplateList:
             return APIConstant.templateList
+        case .getTemplateQuestion(let templateId):
+            return APIConstant.templateList + "/\(templateId)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getTemplateList:
+        case .getTemplateList, .getTemplateQuestion:
             return .get
         }
     }
     
     var task: Task {
         switch self {
-        case .getTemplateList:
+        case .getTemplateList, .getTemplateQuestion:
             return .requestPlain
         }
     }
@@ -38,6 +41,8 @@ extension WriteService: BaseTargetType {
     var headers: [String : String]? {
         switch self {
         case .getTemplateList:
+            return NetworkConstant.hasTokenHeader
+        case .getTemplateQuestion:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 서버통신용 모델
-struct TemplateContentModel {
+struct TemplateContentModel: Codable {
     let title: String
     let guideline: String
     let questions: [String]

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
@@ -35,7 +35,6 @@ extension TemplateContentViewModel {
         /// 서버 통신으로 template Id request 후에 데이터 가져오기
         WriteAPI.shared.getTemplateQuestion(param: templateId) { result in
             guard let result = result, let data = result.data else { return }
-            print("템플릿에 맞는 질문 목록입니다.", data)
             self.output.send(data)
         }
     }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
@@ -22,7 +22,7 @@ class TemplateContentViewModel: ViewModelType {
     
     func transform(input: Input) -> AnyPublisher<TemplateContentModel, Never> {
         input.sink{[weak self] templateId in
-            self?.getTemplateContents(templateId)
+            self?.getTemplateContents(templateId + 1)
         }
         .store(in: &cancellables)
         
@@ -33,51 +33,10 @@ class TemplateContentViewModel: ViewModelType {
 extension TemplateContentViewModel {
     private func getTemplateContents(_ templateId: Int) {
         /// 서버 통신으로 template Id request 후에 데이터 가져오기
-        templateContent = TemplateContentModel(title: "", guideline: "", questions: [], hints: [])
-        let templateContentDummy = [TemplateContentModel(title: "Free Flow", guideline: "머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요.", questions: [
-            "걱정하고 있는 것들을 자유롭게 나열해보세요."], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기"]), TemplateContentModel(title: "장단점 생각하기", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ]), TemplateContentModel(title: "세번의 왜?", guideline: "내 고민 속 물음의 꼬리를 통해 해결책을 함께 찾아가요!", questions: [
-            "왜 고민이 나타났나요?",
-            "왜 고민이라고 생각하나요?",
-            "왜 고민을 해결하지 못하고 있나요?",
-            "그렇다면, 해결할 수 있는 방법은 무엇인가요?"
-          ], hints: [
-            "ex. 다이어트의 실패",
-            "ex. 반복되는 실패로 자존감이 낮아짐",
-            "ex. 주 3일 운동을 실천하지 못하고 있음",
-            "ex. 새 운동복을 사서 운동 욕구를 자극해야지"
-          ]), TemplateContentModel(title: "단 하나의 목표", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ]), TemplateContentModel(title: "땡스투 새겨보기", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ])]
-        templateContent = templateContentDummy[templateId]
-        output.send(templateContent)
+        WriteAPI.shared.getTemplateQuestion(param: templateId) { result in
+            guard let result = result, let data = result.data else { return }
+            print("템플릿에 맞는 질문 목록입니다.", data)
+            self.output.send(data)
+        }
     }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- 고민작성뷰에서 특정 템플릿을 클릭하였을 때 그에 맞는 템플릿 질문을 조회하는 API를 연결합니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기존에 서버 연결을 고려해서 만들어두었던 뷰모델 부분에 API를 연결하는 부분만 추가했습니다!
- 담인햄이 잘 짜준 포맷 덕분에 쉽게 구현했네용,,,ㅎㅎ 이제 상세보기 뷰와 연결하는 것이랑 토스트 메시지 구현해볼까 합니당


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-08-30 at 14 30 37](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/b2fd93ab-8ca5-49a4-a409-8c429ae74ad1)
<img width="891" alt="스크린샷 2023-08-30 오후 2 30 56" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/a2c37816-c80b-40ce-a589-5b514fc19cd4">

## 🚨 관련 이슈
- Resolved: #42 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
