### PR TITLE
[Feat] 고민작성지 뷰에서 선택한 템플릿의 고민작성뷰 present 구현

### DIFF
--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -12,16 +12,17 @@ import Moya
 final class WriteAPI {
     
     static let shared: WriteAPI = WriteAPI()
-    private let archiveProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
+    private let writeProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     
     public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?
+    public private(set) var templateContentResponse: GeneralResponse<TemplateContentModel>?
     
     
     // MARK: - HomeGemList
     func getTemplateList(completion: @escaping (GeneralArrayResponse<TemplateListModel>?) -> () ) {
-        archiveProvider.request(.getTemplateList) { [weak self] response in
+        writeProvider.request(.getTemplateList) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
@@ -32,6 +33,29 @@ final class WriteAPI {
                     guard let templateList = self?.templateListResponse else { return }
                     print(templateList)
                     completion(templateList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func getTemplateQuestion(param: Int, completion: @escaping (GeneralResponse<TemplateContentModel>?) -> () ) {
+        writeProvider.request(.getTemplateQuestion(templateId: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.templateContentResponse = try
+                    result.map(GeneralResponse<TemplateContentModel>?.self)
+                    print("성공")
+                    print(result)
+                    guard let contentList = self?.templateContentResponse else { return }
+                    print(contentList)
+                    completion(contentList)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum WriteService {
     case getTemplateList
+    case getTemplateQuestion(templateId: Int)
 }
 
 extension WriteService: BaseTargetType {
@@ -18,19 +19,21 @@ extension WriteService: BaseTargetType {
         switch self {
         case .getTemplateList:
             return APIConstant.templateList
+        case .getTemplateQuestion(let templateId):
+            return APIConstant.templateList + "/\(templateId)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getTemplateList:
+        case .getTemplateList, .getTemplateQuestion:
             return .get
         }
     }
     
     var task: Task {
         switch self {
-        case .getTemplateList:
+        case .getTemplateList, .getTemplateQuestion:
             return .requestPlain
         }
     }
@@ -38,6 +41,8 @@ extension WriteService: BaseTargetType {
     var headers: [String : String]? {
         switch self {
         case .getTemplateList:
+            return NetworkConstant.hasTokenHeader
+        case .getTemplateQuestion:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 서버통신용 모델
-struct TemplateContentModel {
+struct TemplateContentModel: Codable {
     let title: String
     let guideline: String
     let questions: [String]

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
@@ -9,6 +9,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol TemplateInfoTVCDelegate: AnyObject {
+    func didPressWritingButton(templateId: Int)
+}
+
 // MARK: - ListTableViewCell
 class TemplateInfoTVC: UITableViewCell {
     
@@ -67,6 +71,7 @@ class TemplateInfoTVC: UITableViewCell {
     
     /// cell의 indexPath를 담을 변수를 선언
     var indexPath: IndexPath?
+    weak var delegate: TemplateInfoTVCDelegate?
 
     // MARK: - View Life Cycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -84,8 +89,9 @@ class TemplateInfoTVC: UITableViewCell {
     // MARK: - Functions
     private func pressBtn() {
         writingBtn.press {
-            /// indexPath[1] : 값의 row data를 담고 있음. 
-            print(self.indexPath?[1] ?? 0,"번째 TVC의 버튼이 눌렸습니다.")
+            /// indexPath[1] : 값의 row data를 담고 있음.
+            let templateId = self.indexPath?[1] ?? 0
+            self.delegate?.didPressWritingButton(templateId: templateId)
         }
     }
     

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -11,6 +11,7 @@ import Then
 import Combine
 
 class TemplateInfoVC: UIViewController {
+class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
     
     // MARK: - Properties
     private let titleLabel = UILabel().then {
@@ -38,11 +39,19 @@ class TemplateInfoVC: UIViewController {
     
     var expandedCells = [Bool]()
     
-    private let templateInfoViewModel = TemplateViewModel()
+    private let templateVM = TemplateViewModel()
     private var cancellables = Set<AnyCancellable>()
     private var templateInfoList: [TemplateInfoPublisherModel] = []
     private let input = PassthroughSubject<Void, Never> ()
-
+    
+    // writeVC Modal시에 화면에 띄어줄 제목을 담아서 보내줌
+    private var templateTitleShortInfoList:
+    [TemplateListPublisherModel] = []
+    
+    private let writeModalVC = WriteModalVC()
+    
+    private var templateId: Int = 1
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         dataBind()
@@ -108,6 +117,18 @@ class TemplateInfoVC: UIViewController {
     private func updateTV(_ list: [ TemplateInfoPublisherModel]) {
         templateInfoList = list
         templateInfoTV.reloadData()
+    }
+    
+    
+    // MARK: - TemplateInfoTVCDelegate
+    func didPressWritingButton(templateId: Int) {
+        let writeVC = WriteVC()
+        writeVC.modalPresentationStyle = .fullScreen
+        self.present(writeVC, animated: true, completion: nil)
+        writeVC.dataBind()
+        self.templateId = templateId
+        writeVC.input.send(templateId)
+        writeVC.templateReload(templateId: templateId, templateTitle: self.templateTitleShortInfoList[templateId].templateTitle, templateInfo: self.templateTitleShortInfoList[templateId].templateDetail)
     }
 }
 
@@ -177,6 +198,7 @@ extension TemplateInfoVC : UITableViewDataSource
         cell.settingData(isExpanded: expandedCells[indexPath.row])
         /// 각 cell 클릭 시 해당하는 cell의 indexPath를 TVC의 indexPath로 전달
         cell.indexPath = indexPath
+        cell.delegate = self
         
         cell.dataBind(model: templateInfoList[indexPath.row])
         

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -10,7 +10,6 @@ import SnapKit
 import Then
 import Combine
 
-class TemplateInfoVC: UIViewController {
 class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
     
     // MARK: - Properties
@@ -60,6 +59,7 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
         registerTV()
         resetCellStatus()
         setObserver()
+        sendTitleInfo()
         input.send() /// 구독 후 ViewModel과 데이터를 연동
     }
     
@@ -106,7 +106,7 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
     }
     
     private func dataBind() {
-        let output = templateInfoViewModel.transform(input: input.eraseToAnyPublisher())
+        let output = templateVM.transform(input: input.eraseToAnyPublisher())
         output.receive(on: DispatchQueue.main)
             .sink { [weak self] list in
                 self?.updateTV(list)
@@ -114,10 +114,19 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
             .store(in: &cancellables)
     }
     
-    private func updateTV(_ list: [ TemplateInfoPublisherModel]) {
+    private func updateTV(_ list: [TemplateInfoPublisherModel]) {
         templateInfoList = list
         templateInfoTV.reloadData()
     }
+    
+    // writeVC Modal시에 화면에 띄어줄 title 및 shortInfo를 보내주기 위한 함수
+    private func sendTitleInfo() {
+        self.templateVM.templateListPublisher.sink{ [weak self] (updatedList : [TemplateListPublisherModel]) in
+            self?.templateTitleShortInfoList = updatedList
+        }
+            .store(in: &cancellables)
+    }
+    
     
     
     // MARK: - TemplateInfoTVCDelegate
@@ -177,7 +186,7 @@ extension TemplateInfoVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 0
     }
-
+    
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         /// expand 된 cell의 높이에 맞게 자동으로 변경해주기 위함
         return UITableView.automaticDimension

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -51,6 +51,7 @@ class TemplateInfoVC: UIViewController {
         registerTV()
         resetCellStatus()
         setObserver()
+        input.send() /// 구독 후 ViewModel과 데이터를 연동
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -102,7 +103,6 @@ class TemplateInfoVC: UIViewController {
                 self?.updateTV(list)
             }
             .store(in: &cancellables)
-        input.send() /// 구독 후 ViewModel과 데이터를 연동
     }
     
     private func updateTV(_ list: [ TemplateInfoPublisherModel]) {

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -25,10 +25,7 @@ class WorryListViewModel: ViewModelType {
     
     func transform(input: Input) -> AnyPublisher<[WorryListPublisherModel], Never> {
         input.sink{[weak self] templateId in
-            ArchiveAPI.shared.getArchiveWorryList(param: templateId) { result in
-                guard let result = result, let data = result.data else { return }
-                self?.convertIdtoWorryList(data.worry)
-            }
+            self?.getNetworkResponse(templateId)
         }
         .store(in: &cancellables)
         
@@ -43,5 +40,12 @@ class WorryListViewModel: ViewModelType {
             worryUpdateList.append(WorryListPublisherModel(templateId: $0.templateId, title: $0.title, period: $0.period, image: UIImage(named: imgName) ?? UIImage() ))
         }
         self.output.send(worryUpdateList)
+    }
+    
+    private func getNetworkResponse(_ templateId: Int) {
+        ArchiveAPI.shared.getArchiveWorryList(param: templateId) { result in
+            guard let result = result, let data = result.data else { return }
+            self.convertIdtoWorryList(data.worry)
+        }
     }
 }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateContentViewModel.swift
@@ -22,7 +22,7 @@ class TemplateContentViewModel: ViewModelType {
     
     func transform(input: Input) -> AnyPublisher<TemplateContentModel, Never> {
         input.sink{[weak self] templateId in
-            self?.getTemplateContents(templateId)
+            self?.getTemplateContents(templateId + 1)
         }
         .store(in: &cancellables)
         
@@ -33,51 +33,10 @@ class TemplateContentViewModel: ViewModelType {
 extension TemplateContentViewModel {
     private func getTemplateContents(_ templateId: Int) {
         /// 서버 통신으로 template Id request 후에 데이터 가져오기
-        templateContent = TemplateContentModel(title: "", guideline: "", questions: [], hints: [])
-        let templateContentDummy = [TemplateContentModel(title: "Free Flow", guideline: "머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요.", questions: [
-            "걱정하고 있는 것들을 자유롭게 나열해보세요."], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기"]), TemplateContentModel(title: "장단점 생각하기", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ]), TemplateContentModel(title: "세번의 왜?", guideline: "내 고민 속 물음의 꼬리를 통해 해결책을 함께 찾아가요!", questions: [
-            "왜 고민이 나타났나요?",
-            "왜 고민이라고 생각하나요?",
-            "왜 고민을 해결하지 못하고 있나요?",
-            "그렇다면, 해결할 수 있는 방법은 무엇인가요?"
-          ], hints: [
-            "ex. 다이어트의 실패",
-            "ex. 반복되는 실패로 자존감이 낮아짐",
-            "ex. 주 3일 운동을 실천하지 못하고 있음",
-            "ex. 새 운동복을 사서 운동 욕구를 자극해야지"
-          ]), TemplateContentModel(title: "단 하나의 목표", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ]), TemplateContentModel(title: "땡스투 새겨보기", guideline: "A or B? 결정이 어렵다면, 장단점을 비교해 최선을 찾아봐요.", questions: [
-            "고민의 선택지를 나열해보세요.",
-            "선택지들의 장점을 생각해보세요.",
-            "선택지들의 단점을 생각해보세요.",
-            "장점과 단점을 비교해 최선의 방법을 찾아보세요."
-          ], hints: [
-            "예) 휴학하고 스펙 쌓기 vs 학교 생활하기",
-            "예) 휴학: 시간을 여유롭게 활용할 수 있다\n     학교: 칼졸업 가능!",
-            "예) 휴학: 비효율적인 시간 관리가 우려된다\n     학교: 취업 준비의 여유가 없다",
-            "예) 휴학 기간 동안 참여할 대외활동 리스트를 세워두자"
-          ])]
-        templateContent = templateContentDummy[templateId]
-        output.send(templateContent)
+        WriteAPI.shared.getTemplateQuestion(param: templateId) { result in
+            guard let result = result, let data = result.data else { return }
+            print("템플릿에 맞는 질문 목록입니다.", data)
+            self.output.send(data)
+        }
     }
 }

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -34,11 +34,6 @@ class TemplateViewModel: ViewModelType {
     
     var templateUpdateList: [TemplateListPublisherModel] = []
     
-    var templateListDummy = [
-           TemplateListModel(templateId: 0, title: "모든 보석 보기", shortInfo: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
-           TemplateListModel(templateId: 1, title: "Free Flow", shortInfo: "빈 공간을 자유롭게 채우기", info: "내가 할 수 있는 선택지를 나열해보세요. 각각 어떤 장점과 단점을 가지고 있나요? 당신의 가능성을 펼쳐 비교해 더 나은 선택을 할 수 있도록 도와줄게요.", hasUsed: true)
-       ]
-    
     lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
     
     // templateinfo

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -76,13 +76,18 @@ extension TemplateViewModel {
             }
         }
     }
+
     private func convertTemplateInfo() {
-        templateInfoList = []
-        templateListDummy.forEach {
-            guard let imgName = idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return }
-            self.templateInfoList.append(TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.title, info: $0.info, image: UIImage(named: imgName) ?? UIImage() ))
+        WriteAPI.shared.getTemplateList { result in
+            guard let result = result, let data = result.data else { return }
+
+            self.templateInfoList = data.compactMap { templateData in
+                guard let imgName = self.idToImgTuple[customKey(index: templateData.templateId, hasUsed: true)] else { return nil }
+                return TemplateInfoPublisherModel(templateId: templateData.templateId, templateTitle: templateData.title, info: templateData.info, image: UIImage(named: imgName) ?? UIImage())
+            }
+
+            self.output.send(self.templateInfoList)
         }
-        self.output.send(templateInfoList)
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -15,7 +15,7 @@ class WriteVC: BaseVC {
     // MARK: - View Model
     private let templateContentVM = TemplateContentViewModel()
     private var cancellables = Set<AnyCancellable>()
-    private let input = PassthroughSubject<Int, Never>.init()
+    let input = PassthroughSubject<Int, Never>.init()
     
     // MARK: - Properties
     private let writeModalVC = WriteModalVC()
@@ -105,7 +105,7 @@ class WriteVC: BaseVC {
     }
     
     // MARK: - Functions
-    private func dataBind() {
+    func dataBind() {
         let output = templateContentVM.transform(
             input: TemplateContentViewModel.Input(input)
         )


### PR DESCRIPTION
## 💪 작업한 내용
- 고민작성지 뷰에서 선택한 템플릿에 해당하는 고민작성뷰를 present해줍니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- '작성하러가기' 버튼이 클릭되었을 때 고민작성뷰 instance를 새로 생성하여 present 해주었습니다. 
- 고민작성뷰가 띄어질 때 templateId를 뷰모델로 send해주어 해당 템플릿의 question과 hint 리스트를 받아옵니다. 
- writeVC의 템플릿 title과 템플릿 shortInfo를 받아오는 delegate부분을 사용하여 templateInfoVC에서 writeVC가 띄어질 때, 선택한 템플릿에 해당하는 제목과 설명이 바로 보여질 수 있게끔 하였습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-08-31 at 13 31 25](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/6b20ad10-c028-4397-9ae7-c39c44f70d4a)


## 🚨 관련 이슈
- Resolved: #44 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
