### PR TITLE
[Feat] 고민 상세뷰 API 연결 및 기타 홈, 상세 코드 수정

### DIFF
--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -16,7 +16,7 @@ final class HomeAPI {
     private init() { }
     
     public private(set) var homeGemListResponse: GeneralArrayResponse<HomeGemListModel>?
-    
+    public private(set) var worryDetailResponse: GeneralResponse<WorryDetailModel>?
    
     // MARK: - HomeGemList
     func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
@@ -26,11 +26,28 @@ final class HomeAPI {
                 do {
                     self?.homeGemListResponse = try
                     result.map(GeneralArrayResponse<HomeGemListModel>?.self)
-                    print("성공")
-                    print(result)
                     guard let gemList = self?.homeGemListResponse else { return }
-                    print(gemList)
                     completion(gemList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - WorryDetail
+    func getWorryDetail(param: Int, completion: @escaping (GeneralResponse<WorryDetailModel>?) -> () ) {
+        homeProvider.request(.worryDetail(worryId: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.worryDetailResponse = try result.map(GeneralResponse<WorryDetailModel>?.self)
+                    guard let worryDetail = self?.worryDetailResponse else { return }
+                    completion(worryDetail)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -18,5 +18,10 @@ struct APIConstant {
         return url
     }()
     
-    static let homeWorryList = "/worry/list"
+    static let worryList = "/worry/list"
+    static let worry = "/worry"
+    static let deadline = "/worrry/deadline"
+    static let myAnswer = "/worry/myanswer"
+    static let template = "/template"
+    static let review = "/review"
 }

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum HomeService {
     case homeGemList(isSolved: Int)
+    case worryDetail(worryId: Int)
 }
 
 extension HomeService: BaseTargetType {
@@ -17,27 +18,29 @@ extension HomeService: BaseTargetType {
     var path: String {
         switch self {
         case .homeGemList(let isSolved):
-            return APIConstant.homeWorryList + "/\(isSolved)"
+            return APIConstant.worryList + "/\(isSolved)"
+        case .worryDetail(let worryId):
+            return APIConstant.worry + "/\(worryId)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .homeGemList:
+        case .homeGemList, .worryDetail:
             return .get
         }
     }
     
     var task: Task {
         switch self {
-        case .homeGemList:
+        case .homeGemList, .worryDetail:
             return .requestPlain
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeGemList:
+        case .homeGemList, .worryDetail:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
@@ -10,11 +10,20 @@ import Foundation
 // MARK: - WorryDetailModel
 struct WorryDetailModel: Codable {
     let title: String
-    let templateId, deadline: Int
-    let questions, answers: [String]
-    let period, updatedAt, finalAnswer: String
-    let review: Review
+    let templateId: Int
+    let subtitles, answers: [String]
+    let period, updatedAt, deadline: String
+    let dDay: Int
+    let finalAnswer: String?
+    let review: Review?
+    
+    enum CodingKeys : String, CodingKey {
+        case dDay = "d-day"
+        case title, templateId, subtitles, answers, period, updatedAt, deadline, finalAnswer, review
+    }
 }
+
+
 
 // MARK: - Review
 struct Review: Codable {

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -129,8 +129,15 @@ final class HomeGemStoneVC: BaseVC {
 // MARK: - CollectionView
 extension HomeGemStoneVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let idx = gemIndexDict[indexPath.item], idx < gemStoneList.count else { return }
-        let worryId = gemStoneList[idx].worryId
+        var worryId = 0
+        switch pageType {
+        case .digging:
+            guard let idx = gemIndexDict[indexPath.item], idx < gemStoneList.count else { return }
+            worryId = gemStoneList[idx].worryId
+        case .dug:
+            worryId = gemStoneList[indexPath.row].worryId
+        }
+       
         let vc = HomeWorryDetailVC(worryId: worryId, type: pageType)
         vc.modalPresentationStyle = .fullScreen
         vc.modalTransitionStyle = .coverVertical

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
@@ -48,8 +48,9 @@ final class HomeWorryDetailFooterView: UITableViewHeaderFooterView {
     }
     
     // MARK: - Function
-    func setData(updateAt: String) {
+    func setData(updateAt: String, finalAnswer: String = "") {
         writtenDateLabel.text = updateAt
+        answerLabel.text = finalAnswer
     }
     
     func setDiggingLayout() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailTVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailTVC.swift
@@ -64,6 +64,7 @@ extension HomeWorryDetailTVC {
         worryQuestion.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.directionalHorizontalEdges.equalToSuperview().inset(14)
+            $0.height.equalTo(18)
         }
         
         worryAnswer.snp.makeConstraints {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -201,15 +201,34 @@ final class HomeWorryDetailVC: BaseVC {
     }
     
     private func updateUI(worryDetail: WorryDetailModel) {
-        questions = worryDetail.questions
+        questions = worryDetail.subtitles
         answers = worryDetail.answers
         updateDate = worryDetail.updatedAt
         worryTitle = worryDetail.title
         templateId = worryDetail.templateId
-        /// 넘어오는 값이 -1일 경우 String 값으로 표현
-        deadline = worryDetail.deadline < 0 ? "∞" : "\(worryDetail.deadline)"
-        navigationBarView.setTitleText(text: "고민캐기 D-\(deadline)")
         period = worryDetail.period
+
+        switch pageType {
+        case .digging:
+            if worryDetail.dDay > 0 {
+                dDay = "-\(worryDetail.dDay)"
+            } else if worryDetail.dDay < 0 {
+                dDay = "+\(worryDetail.dDay)"
+            } else if worryDetail.dDay == 0 {
+                dDay = "day"
+            } else {
+                dDay = "-∞"
+            }
+            navigationBarView.setTitleText(text: "고민캐기 D\(dDay)")
+        case .dug:
+            if let finalAnswer = worryDetail.finalAnswer {
+                self.finalAnswer = finalAnswer
+                if let review = worryDetail.review {
+                    self.reviewView.setData(content: review.content, updatedAt: review.updatedAt)
+                }
+            }
+            navigationBarView.setTitleText(text: "나의 고민")
+        }
         
         /// 갱신된 데이터로 테이블뷰 정보를 갱신
         /// -> 갱신된 데이터를 적용한 콘텐트 크기를 아직 모르니 contentSize는 각 셀,헤더,푸터의 estimatedSize 합으로 일단 지정됨

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -98,7 +98,6 @@ final class HomeWorryDetailVC: BaseVC {
         setNaviButtonAction()
         setupTableView()
         setReviewTextView()
-        dataBind()
         hideKeyboardWhenTappedAround()
         setPressAction()
     }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -102,7 +102,21 @@ final class HomeWorryDetailVC: BaseVC {
         hideKeyboardWhenTappedAround()
         setPressAction()
     }
+
     override func viewWillLayoutSubviews() {
+        setDynamicLayout()
+    }
+      
+    override func viewWillAppear(_ animated: Bool) {
+        self.addKeyboardObserver()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.removeKeyboardObserver()
+    }
+
+    // MARK: - Function
+    private func setDynamicLayout() {
         /// 테이블 뷰 contentSize.height 보다 1이상 커야지 footer뷰가 제대로 나옴
         let tableContentHeight = worryDetailTV.contentSize.height + 1
         worryDetailTV.snp.updateConstraints {
@@ -113,6 +127,7 @@ final class HomeWorryDetailVC: BaseVC {
             worryDetailScrollView.snp.updateConstraints {
                 $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(89.adjustedH)
             }
+            
             worryDetailContentView.snp.updateConstraints {
                 $0.height.equalTo(tableContentHeight)
             }
@@ -130,67 +145,14 @@ final class HomeWorryDetailVC: BaseVC {
                 worryDetailContentView.snp.updateConstraints {
                     $0.height.equalTo(tableContentHeight + reviewSpacing + restReviewViewHeight + defaultTextViewHeight)
                 }
-               
+
                 reviewView.snp.updateConstraints {
                     $0.height.equalTo(restReviewViewHeight + defaultTextViewHeight)
                 }
             }
-            
         }
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        self.addKeyboardObserver()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        self.removeKeyboardObserver()
-    }
-    
-    // MARK: - Function
-    private func addKeyboardObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.keyboardWillAppear(_:)),
-            name: UIResponder.keyboardWillShowNotification,
-            object: nil
-        )
-        
-        NotificationCenter.default.addObserver(
-            self, selector: #selector(keyboardWillDisappear),
-            name: UIResponder.keyboardWillHideNotification,
-            object: nil)
-
-    }
-    
-    
-    private func removeKeyboardObserver() {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardWillShowNotification,
-            object: nibName
-        )
-        
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardWillHideNotification,
-            object: nibName
-        )
-    }
-    @objc
-    func keyboardWillAppear(_ notification: NSNotification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                UIView.animate(withDuration: 0.1, animations: {
-                    self.worryDetailScrollView.contentInset.bottom = keyboardSize.height + 50
-                })
-        }
-    }
-    @objc
-    func keyboardWillDisappear(_ notification: NSNotification) {
-        worryDetailScrollView.contentInset.bottom = .zero
-    }
-    
-    // MARK: - Function
     private func setNaviButtonAction() {
         navigationBarView.setLeftButtonAction {
             self.dismiss(animated: true, completion: nil)
@@ -252,9 +214,50 @@ final class HomeWorryDetailVC: BaseVC {
         navigationBarView.setTitleText(text: "고민캐기 D-\(deadline)")
         period = worryDetail.period
         worryDetailTV.reloadData()
+// MARK: - KeyBoard
+extension HomeWorryDetailVC {
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillAppear),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(keyboardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
     }
     
+    
+    private func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillShowNotification,
+            object: nibName
+        )
+        
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nibName
+        )
+    }
+    @objc
+    func keyboardWillAppear(_ notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                UIView.animate(withDuration: 0.1, animations: {
+                    self.worryDetailScrollView.contentInset.bottom = keyboardSize.height + 50
+                })
+        }
+    }
+    @objc
+    func keyboardWillDisappear(_ notification: NSNotification) {
+        worryDetailScrollView.contentInset.bottom = .zero
+    }
 }
+
 // MARK: - TextView
 extension HomeWorryDetailVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
@@ -288,7 +291,6 @@ extension HomeWorryDetailVC: UITextViewDelegate {
         let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
         self.reviewTextViewHeight = newSize.height
     }
-    
 }
 
 
@@ -297,7 +299,7 @@ extension HomeWorryDetailVC: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return questions.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: HomeWorryDetailTVC.className) as? HomeWorryDetailTVC else { return UITableViewCell() }
@@ -313,7 +315,6 @@ extension HomeWorryDetailVC: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: HomeWorryDetailHeaderView.className) as? HomeWorryDetailHeaderView else { return nil }
         headerCell.setData(templateId: self.templateId, title: self.worryTitle, type: pageType, period: period)
-        
         return headerCell
     }
     

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -17,7 +17,14 @@ final class HomeWorryDetailVC: BaseVC {
     private var cancellables = Set<AnyCancellable>()
     private let input = PassthroughSubject<Int, Never>.init()
     
-    private let navigationBarView = CustomNavigationBarView(leftType: .close, rightType: .edit, title: "고민캐기")
+    private lazy var navigationBarView: CustomNavigationBarView = {
+        switch self.pageType {
+        case .digging:
+            return CustomNavigationBarView(leftType: .close, rightType: .edit, title: "고민캐기")
+        case .dug:
+            return CustomNavigationBarView(leftType: .close, rightType: .delete, title: "고민캐기")
+        }
+    }()
     
     private let worryDetailTV = UITableView().then {
         $0.backgroundColor = .clear

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -320,11 +320,13 @@ extension HomeWorryDetailVC: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let footerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: HomeWorryDetailFooterView.className) as? HomeWorryDetailFooterView else { return nil }
-        footerCell.setData(updateAt: updateDate)
+
         switch pageType {
         case .digging:
+            footerCell.setData(updateAt: updateDate)
             footerCell.setDiggingLayout()
         case .dug:
+            footerCell.setData(updateAt: updateDate, finalAnswer: finalAnswer)
             footerCell.setDugLayout()
         }
         return footerCell
@@ -337,7 +339,7 @@ extension HomeWorryDetailVC {
         self.view.addSubviews([navigationBarView, worryDetailScrollView])
         
         navigationBarView.snp.makeConstraints {
-            $0.left.right.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.height.equalTo(50)
         }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -173,9 +173,6 @@ final class HomeWorryDetailVC: BaseVC {
         worryDetailTV.estimatedSectionHeaderHeight = 200
         worryDetailTV.estimatedRowHeight = 200
         worryDetailTV.estimatedSectionFooterHeight = 200
-        worryDetailTV.rowHeight = UITableView.automaticDimension
-        worryDetailTV.sectionHeaderHeight = UITableView.automaticDimension
-        worryDetailTV.sectionFooterHeight = UITableView.automaticDimension
         worryDetailTV.backgroundView = backgroundImageView
     }
     
@@ -213,7 +210,18 @@ final class HomeWorryDetailVC: BaseVC {
         deadline = worryDetail.deadline < 0 ? "∞" : "\(worryDetail.deadline)"
         navigationBarView.setTitleText(text: "고민캐기 D-\(deadline)")
         period = worryDetail.period
+        
+        /// 갱신된 데이터로 테이블뷰 정보를 갱신
+        /// -> 갱신된 데이터를 적용한 콘텐트 크기를 아직 모르니 contentSize는 각 셀,헤더,푸터의 estimatedSize 합으로 일단 지정됨
         worryDetailTV.reloadData()
+        /// worryDetailTV 높이를 contentSize.height으로 업데이트
+        worryDetailTV.frame.size.height = worryDetailTV.contentSize.height
+        /// layout을 업데이트 시키면서 worryDetailTV의 콘텐트 사이즈 값이 실제 크기에 맞게 조정
+        /// -> layoutSubView 메서드가 호출되면서 setDynamicLayout호출
+        worryDetailTV.layoutIfNeeded()
+    }
+    
+}
 // MARK: - KeyBoard
 extension HomeWorryDetailVC {
     private func addKeyboardObserver() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -103,12 +103,12 @@ final class HomeWorryDetailVC: BaseVC {
         setPressAction()
     }
 
-    override func viewWillLayoutSubviews() {
-        setDynamicLayout()
-    }
-      
     override func viewWillAppear(_ animated: Bool) {
         self.addKeyboardObserver()
+    }
+    
+    override func viewWillLayoutSubviews() {
+        setDynamicLayout()
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -54,23 +54,24 @@ final class HomeWorryDetailVC: BaseVC {
         $0.backgroundColor = .kGray3
         $0.layer.cornerRadius = 8
     }
-    
+    private let reviewView = WorryDetailReviewView()
     private var questions = [String]()
     private var answers = [String]()
     private var updateDate = ""
     private var worryTitle = ""
     private var templateId = 1
-    private var deadline = ""
+    private var dDay = ""
     private var period = ""
     private var pageType: PageType = .digging
     
-    private let reviewView = WorryDetailReviewView()
     private let restReviewViewHeight: CGFloat = 67
     private var defaultTextViewHeight: CGFloat = 53
     private let reviewSpacing: CGFloat = 32
     private let placeholderText = "이 고민을 통해 배운점 또는 생각을 자유롭게 적어보세요"
     private var reviewTextViewHeight: CGFloat = 0
-
+    private var finalAnswer = ""
+    private var reivew: Review = Review(content: "", updatedAt: "")
+    
     // MARK: - Initialization
     init(worryId: Int, type: PageType) {
         super.init(nibName: nil, bundle: nil)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
@@ -48,6 +48,11 @@ final class WorryDetailReviewView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Function
+    func setData(content: String, updatedAt: String) {
+        reviewTextView.text = content
+        reviewDateLabel.text = updatedAt
+    }
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
@@ -40,7 +40,6 @@ final class WorryDetailReviewView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
-        setTextView()
         setLayout()
     }
     
@@ -50,8 +49,12 @@ final class WorryDetailReviewView: UIView {
     
     // MARK: - Function
     func setData(content: String, updatedAt: String) {
-        reviewTextView.text = content
         reviewDateLabel.text = updatedAt
+        if !content.isEmpty {
+            reviewTextView.text = content
+        }else {
+            reviewTextView.text = "이 고민을 통해 배운점 또는 생각을 자유롭게 적어보세요"
+        }
     }
 }
 
@@ -62,9 +65,6 @@ extension WorryDetailReviewView {
         self.layer.borderWidth = 1
         self.layer.cornerRadius = 8
         self.layer.borderColor = UIColor.kGray3.cgColor
-    }
-    
-    private func setTextView() {
     }
     
     private func setLayout() {

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
@@ -18,6 +18,7 @@ final class HomeWorryDetailViewModel: ViewModelType {
     private var cancellables = Set<AnyCancellable>()
     private var worryId = 1
     
+    // MARK: - Function
     func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<WorryDetailModel, Never> {
         input
             .sink { [weak self] worryId in
@@ -27,20 +28,16 @@ final class HomeWorryDetailViewModel: ViewModelType {
         
         return output.eraseToAnyPublisher()
     }
-    
-    // MARK: - Function
-    private func getWorryDetail(worryId: Int) {
-        /// 서버 통신으로 worryId 값 주고 데이터 받아옴
-        let result = WorryDetailModel(title: "고민 제목", templateId: 1, deadline: 1, questions: ["지금 나의 고민1", "지금 나의 고민2", "지금 나의 고민3", "지금 나의 고민4"], answers: [
-            "걱정하고 있는 걸 사실대로",
-            "걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 ",
-            "",
-            "걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다.걱정하고 있는 걸 사실대로 써봅시다."
-        ], period: "2023.07.23 ~ 2023.07.24", updatedAt: "작성일 2023.07.23", finalAnswer: "마지막 대답", review: Review(content: "리뷰", updatedAt: "2023.09.23"))
-        
-        output.send(result)
-    }
-    
 }
 
+// MARK: - Network
+extension HomeWorryDetailViewModel {
+    private func getWorryDetail(worryId: Int) {
+        HomeAPI.shared.getWorryDetail(param: worryId) { res in
+            guard let res = res else { return }
+            guard let data = res.data else { return }
+            self.output.send(data)
+        }
+    }
+}
 


### PR DESCRIPTION
## 💪 작업한 내용
- 고민 상세 뷰 서버 연결
  - 리스폰스가 기존에 노션에 써져 있던것을 보고 세팅했는데 달라진에 있어 그 부분 고려해 VC 내 로직을 수정하였습니다.
 
- 고민 상세 뷰 페이지별 로직 수정
  -  고민 상세뷰를 고민 중, 완료에 따라서 따로 VC를 만들지 않고 겹치는 부분이 많아 하나의 VC로 만들어서 사용하고 있는데 각 타입별로 로직이 제대로 적용 되어있지 않은 부분이 좀 있어 그 부분을 제대로 작동하게 수정하였습니다.

- 기타 자잘한 코드 수정

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
### 테이블 뷰 길이 이슈
  - 아래 gif 처럼 테이블 뷰의 길이 실제 콘텐트의 길이보다 길어지는 문제가 있었습니다. 
  - 더미데이터를 넘겨줄 때는 문제가 없었는데 서버연결해서 데이터 넘겨주니 이런 문제가 발생하였습니다.
  - 일단 디버깅을 해보니 더미데이터를 넘겨줬을 때는 reload가 되고 viewWillLayoutSubView 라는 생명주기 메서드가 자동적으로 실행되었고 내부에 작성해 놓은 layout을 업데이트 하는 코드로 테이블 뷰의 길이를 제대로 맞춰 줄 수 있었습니다. 
  - 더미데이터로 전달시 reload했을때 `테이블 뷰의 콘텐트 사이즈가 실제 콘텐트 사이즈 만큼 적용이 바로 되었고`, 그것이 viewWillLayout에서 테이블 뷰 사이즈에도 적용되어 정상적으로 작동한것 같습니다. 
![Simulator Screen Recording - iPhone 13 mini - 2023-08-28 at 22 23 56](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/b5127b1e-3cda-4d14-9ed5-df2877e9d276)

### 문제 해결 (aka 삽질)
- 그럼 왜 서버 연결을 해서 데이터를 전달 했을때 이슈가 생겼을 까요? 
  - 저도 정확한 원인은 모르겠으나 추측하건데 더미데이터는 이미 존재하는 고정된 데이터였으니까 컴파일러가?(혹은 프레임워크 상에서?) 그 데이터를 테이블뷰에 적용해서 그 사이즈를 바로 추론 할 수 있었는데 서버 데이터는 그렇지 않아서 발생한 것 같습니다..
- 그래서 그런지 코드에서 테이블 뷰에 estimatedHeight으로 적용한 크기 (고민 완료뷰 기준)셀 200x4 + 푸터200 + 헤더200 = 1200인데  tableView를 reload했을때 테이블의 contentSize 또한 1222로 설정 되어 있었습니다. (그래서 길게 보여진것)
- 근데 이상한 것은 서버 데이터를 받아서 쓸때는 테이블 뷰를 reload해도 viewWillLayout 같은 생명주기 메서드가 자동으로 실행이 되지 않았습니다. 
`그러다가 고민완료 뷰에서 하단 텍스트 뷰를 클릭시 테이블 뷰의 높이가 다시 제대로 업데이트 되는 것을 알 수 있었습니다. `
![Simulator Screen Recording - iPhone 13 mini - 2023-09-02 at 17 22 45](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/60e04db2-1f2d-49b8-b446-34bd9c825881)
- 키보드 클릭시 아래의 코드가 실행되는데 여기에 힌트를 얻어 이슈를 해결하려고 했습니다.
```swift
@objc
    func keyboardWillAppear(_ notification: NSNotification) {
        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
                UIView.animate(withDuration: 0.1, animations: {
                    self.worryDetailScrollView.contentInset.bottom = keyboardSize.height + 50
                })
        }
    }
```
- 위 코드에서 scrollView의 contentInset.bottom을 적용하면 되나? 생각하고 테이블뷰를 reload하고 위 코드를 적용했지만 변화가 없었고
- 키보드 작동에 따라 뷰가 정상적으로 layout 되는 것은 아마 전체적으로 뷰의 layout을 잡아주는 과정이 내부적으로 발생하기 때문이지 저 코드 때문은 아니였던 것 같습니다.
  
- 결국 이리저리 삽질 하다가 아래의 순서로 실행해야 작동되는 것을 알게 되었습니다. 

```swift
        /// 갱신된 데이터로 테이블뷰 정보를 갱신
        /// -> 갱신된 데이터를 적용한 콘텐트 크기를 아직 모르니 contentSize는 각 셀,헤더,푸터의 estimatedSize 합으로 일단 지정됨
        worryDetailTV.reloadData()
        /// worryDetailTV 높이를 contentSize.height으로 업데이트
        worryDetailTV.frame.size.height = worryDetailTV.contentSize.height
        /// layout을 업데이트 시키면서 worryDetailTV의 콘텐트 사이즈 값이 실제 크기에 맞게 조정
        /// -> layoutSubView 메서드가 호출되면서 setDynamicLayout호출
        worryDetailTV.layoutIfNeeded()
 ```

- 이 솔루션에 대한 근거도 확실하지 않은데.. 제 추론은 아래 이미지처럼 작동되는 것 같습니다.
   - 여기서 중요했던것은 3번 코드를 그냥 실행하면 contentSize가 그대로인데, 테이블 뷰 자체의 높이를 테이블 뷰의 콘텐트의 실제 높이 이상으로 설정해주면 layoutIfNeeded같은 메서드를 통해 contentSize도 실제 높이를 잡게 된다는 것을 알 수 있었습니다.(왜 그렇게 되는건지는 아직도 모르겠습니다..)
   
![‎‎PR Image ‎001 ‎001](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/62f8703e-333d-411f-b8c6-1d0f93f00d4a)

PR을 이렇게 길게 쓴건 또 오랜만이네요,,삽질 덕분에
## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2023-09-03 at 10 38 35](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/37e787b3-2eb0-49a3-8ef3-03c7dc3d4990)


## 🚨 관련 이슈
- Resolved: #35 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
