### PR TITLE
[Chore] templateInfoModel과 templateListModel 병합 및 templateVM 수정

### DIFF
--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -18,7 +18,10 @@ struct APIConstant {
         return url
     }()
     
-    static let homeWorryList = "/worry/list"
-    static let archiveWorryList = "/worry"
-    static let templateList = "/template"
+    static let worryList = "/worry/list"
+    static let worry = "/worry"
+    static let deadline = "/worrry/deadline"
+    static let myAnswer = "/worry/myanswer"
+    static let template = "/template"
+    static let review = "/review"
 }

--- a/KAERA/KAERA/Network/Services/ArchiveService.swift
+++ b/KAERA/KAERA/Network/Services/ArchiveService.swift
@@ -17,7 +17,7 @@ extension ArchiveService: BaseTargetType {
     var path: String {
         switch self {
         case .archiveWorryList:
-            return APIConstant.archiveWorryList
+            return APIConstant.worry
         }
     }
     

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -17,7 +17,7 @@ extension HomeService: BaseTargetType {
     var path: String {
         switch self {
         case .homeGemList(let isSolved):
-            return APIConstant.homeWorryList + "/\(isSolved)"
+            return APIConstant.worryList + "/\(isSolved)"
         }
     }
     

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -18,9 +18,9 @@ extension WriteService: BaseTargetType {
     var path: String {
         switch self {
         case .getTemplateList:
-            return APIConstant.templateList
+            return APIConstant.template
         case .getTemplateQuestion(let templateId):
-            return APIConstant.templateList + "/\(templateId)"
+            return APIConstant.template + "/\(templateId)"
         }
     }
     

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateListModel.swift
@@ -18,17 +18,10 @@ struct TemplateListModel: Codable {
 }
 
 /// View에 뿌려주기 위한 model
-struct TemplateListPublisherModel {
-    let templateId: Int
-    let templateTitle: String
-    let templateDetail: String
-    let image: UIImage
-}
-
-/// View에 뿌려주기 위한 model
 struct TemplateInfoPublisherModel {
     let templateId: Int
     let templateTitle: String
     let info: String
+    let templateDetail: String
     let image: UIImage
 }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalCVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveModal/ArchiveModalCVC.swift
@@ -88,7 +88,7 @@ extension ArchiveModalCVC{
     }
     
     // MARK: - DataBind
-    func dataBind(model: TemplateListPublisherModel, indexPath: IndexPath) {
+    func dataBind(model: TemplateInfoPublisherModel, indexPath: IndexPath) {
         templateImage.image = model.image
         templateTitle.text = model.templateTitle
         templateDetail.text = model.templateDetail

--- a/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
+++ b/KAERA/KAERA/Scenes/ViewModel/TemplateViewModel.swift
@@ -31,25 +31,21 @@ class TemplateViewModel: ViewModelType {
         customKey(index: 6, hasUsed: true): "gem_yellow_s_on",
         customKey(index: 6, hasUsed: false): "gem_yellow_s_off"
     ]
-    
-    var templateUpdateList: [TemplateListPublisherModel] = []
-    
-    var templateListDummy = [
-           TemplateListModel(templateId: 0, title: "모든 보석 보기", shortInfo: "그동안 캐낸 모든 보석을 볼 수 있어요", info: "어떤 질문도 던지지 않아요. 캐라 도화지에서 머릿 속 얽혀있는 고민 실타래들을 마음껏 풀어내세요!", hasUsed: true),
-           TemplateListModel(templateId: 1, title: "Free Flow", shortInfo: "빈 공간을 자유롭게 채우기", info: "내가 할 수 있는 선택지를 나열해보세요. 각각 어떤 장점과 단점을 가지고 있나요? 당신의 가능성을 펼쳐 비교해 더 나은 선택을 할 수 있도록 도와줄게요.", hasUsed: true)
-       ]
-    
-    lazy var templateListPublisher = CurrentValueSubject<[TemplateListPublisherModel], Never>(templateUpdateList)
-    
-    // templateinfo
+
+    /// 고민보관함뷰의 고민 작성지 뷰에서 사용
     private var templateInfoList: [TemplateInfoPublisherModel] = []
-    private var cancellables = Set<AnyCancellable>()
     
+    /// 고민작성뷰와 고민보관함뷰의 modalVC에서 사용
+    var templateUpdateList: [TemplateInfoPublisherModel] = []
+        
     typealias Input = AnyPublisher<Void, Never>
     typealias Output = AnyPublisher<[TemplateInfoPublisherModel], Never>
     
     private let output = PassthroughSubject<[TemplateInfoPublisherModel], Never> ()
-
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    /// 고민보관함뷰의 고민 작성지 뷰에서 사용
     func transform(input: Input) -> AnyPublisher<[TemplateInfoPublisherModel], Never> {
         input.sink{[weak self] _ in
             self?.convertTemplateInfo()
@@ -58,9 +54,13 @@ class TemplateViewModel: ViewModelType {
         return output.eraseToAnyPublisher()
     }
     
-    init() {
-        templateUpdateList = []
-        convertIdtoImg()
+    /// 고민작성뷰와 고민보관함뷰의 modalVC에서 사용
+    func transformModal(input: Input) -> AnyPublisher<[TemplateInfoPublisherModel], Never> {
+        input.sink{[weak self] _ in
+            self?.convertIdtoImg()
+        }
+        .store(in: &cancellables)
+        return output.eraseToAnyPublisher()
     }
 }
 
@@ -70,10 +70,11 @@ extension TemplateViewModel {
         WriteAPI.shared.getTemplateList { result in
             guard let result = result, let data = result.data else { return }
 
-            data.forEach {
-                guard let imgName = self.idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return }
-                self.templateUpdateList.append(TemplateListPublisherModel(templateId: $0.templateId, templateTitle: $0.title, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage() ))
+            self.templateUpdateList = data.compactMap {
+                guard let imgName = self.idToImgTuple[customKey(index: $0.templateId, hasUsed: $0.hasUsed)] else { return nil }
+                return TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.title, info: $0.info, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage())
             }
+            self.output.send(self.templateUpdateList)
         }
     }
 
@@ -81,9 +82,9 @@ extension TemplateViewModel {
         WriteAPI.shared.getTemplateList { result in
             guard let result = result, let data = result.data else { return }
 
-            self.templateInfoList = data.compactMap { templateData in
-                guard let imgName = self.idToImgTuple[customKey(index: templateData.templateId, hasUsed: true)] else { return nil }
-                return TemplateInfoPublisherModel(templateId: templateData.templateId, templateTitle: templateData.title, info: templateData.info, image: UIImage(named: imgName) ?? UIImage())
+            self.templateInfoList = data.compactMap {
+                guard let imgName = self.idToImgTuple[customKey(index: $0.templateId, hasUsed: true)] else { return nil }
+                return TemplateInfoPublisherModel(templateId: $0.templateId, templateTitle: $0.title, info: $0.info, templateDetail: $0.shortInfo, image: UIImage(named: imgName) ?? UIImage())
             }
 
             self.output.send(self.templateInfoList)

--- a/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalCVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalCVC.swift
@@ -86,7 +86,7 @@ extension WriteModalCVC {
         }
     }
     
-    func dataBind(model: TemplateListPublisherModel, indexPath: IndexPath) {
+    func dataBind(model: TemplateInfoPublisherModel, indexPath: IndexPath) {
         templateImage.image = model.image
         templateTitle.text = model.templateTitle
         templateDetail.text = model.templateDetail


### PR DESCRIPTION
## 💪 작업한 내용
- templateViewModel에서 사용했던 두 모델(templateInfoModel, templateListModel)을 병합합니다. 
- writeModalVC와 archiveModalVC에서 사용했던 templateListModel대신에 templateInfoModel로 변경하여 하나로 고정합니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 잘 수정했습니다!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #49 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
