### PR TITLE
[Feat] 고민 편집 창 구현

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		E7A94CC92AA6A46800F231D0 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CC82AA6A46800F231D0 /* KakaoSDKCommon */; };
 		E7A94CCB2AA6A46800F231D0 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CCA2AA6A46800F231D0 /* KakaoSDKUser */; };
 		E7A94CCD2AAC149900F231D0 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A94CCC2AAC149900F231D0 /* Environment.swift */; };
+		E7A94CCF2AAD9F9100F231D0 /* HomeWorryEditVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A94CCE2AAD9F9100F231D0 /* HomeWorryEditVC.swift */; };
 		E7AC12212A51CFFD00FE504C /* GeneralResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */; };
 		E7AC12232A51D08300FE504C /* Temp_DataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AC12222A51D08300FE504C /* Temp_DataModel.swift */; };
 		E7AC122F2A51D54900FE504C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC122E2A51D54900FE504C /* CombineMoya */; };
@@ -162,6 +163,7 @@
 		E7A94CC12AA4569300F231D0 /* KAERA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KAERA.entitlements; sourceTree = "<group>"; };
 		E7A94CC32AA484E300F231D0 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		E7A94CCC2AAC149900F231D0 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		E7A94CCE2AAD9F9100F231D0 /* HomeWorryEditVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryEditVC.swift; sourceTree = "<group>"; };
 		E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralResponse.swift; sourceTree = "<group>"; };
 		E7AC12222A51D08300FE504C /* Temp_DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp_DataModel.swift; sourceTree = "<group>"; };
 		E7BB4F3A2A5ED3610018312B /* HomeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVC.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */,
 				E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */,
 				E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */,
+				E7A94CCE2AAD9F9100F231D0 /* HomeWorryEditVC.swift */,
 			);
 			path = HomeWorryDetail;
 			sourceTree = "<group>";
@@ -713,6 +716,7 @@
 				85887D992A60431000F7FB21 /* ArchiveModalVC.swift in Sources */,
 				85887D902A5EFA2C00F7FB21 /* WritePickerVC.swift in Sources */,
 				85887D8C2A5D084800F7FB21 /* TemplateListModel.swift in Sources */,
+				E7A94CCF2AAD9F9100F231D0 /* HomeWorryEditVC.swift in Sources */,
 				E79AAC362A52F2C300F3F439 /* UILabel+.swift in Sources */,
 				E79AAC3A2A52F2C300F3F439 /* Adjusted+.swift in Sources */,
 				E79AAC312A52F2C300F3F439 /* UIView+.swift in Sources */,

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -157,9 +157,12 @@ final class HomeWorryDetailVC: BaseVC {
         navigationBarView.setLeftButtonAction {
             self.dismiss(animated: true, completion: nil)
         }
-        
         navigationBarView.setRightButtonAction {
-            //TODO: edit 창 띄우기
+            let editVC = HomeWorryEditVC()
+            editVC.worryDetail = self.worryDetailViewModel.worryDetail
+            editVC.modalPresentationStyle = .overCurrentContext
+            editVC.modalTransitionStyle = .coverVertical
+            self.present(editVC, animated: true)
         }
     }
     

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -1,0 +1,109 @@
+//
+//  HomeWorryEditVC.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/09/10.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class HomeWorryEditVC: BaseVC {
+    
+    var worryDetail: WorryDetailModel?
+    
+    private let menuStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.backgroundColor = .kGray3
+        $0.distribution = .fillEqually
+        $0.spacing = 1
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+    }
+    
+    private let editWorryButton = UIButton().then {
+        $0.setTitle("글 수정하기", for: .normal)
+        $0.backgroundColor = .kGray2
+    }
+    
+    private let editDeadlineButton = UIButton().then {
+        $0.setTitle("데드라인 수정하기", for: .normal)
+        $0.backgroundColor = .kGray2
+    }
+    
+    private let deleteWorryButton = UIButton().then {
+        $0.setTitle("글 삭제하기", for: .normal)
+        $0.backgroundColor = .kGray2
+    }
+    
+    private let cancelButton = UIButton().then {
+        $0.backgroundColor = .kGray2
+        $0.setTitle("취소", for: .normal)
+        $0.setTitleColor(UIColor.kRed1, for: .normal)
+        $0.layer.cornerRadius = 12
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setPressAction()
+        hideKeyboardWhenTappedAround()
+    }
+    // MARK: - Function
+    private func setPressAction() {
+        editWorryButton.press {
+            //TODO: 고민 수정하기 -> 수정용 작성페이지(고민 상세에 있던 데이터 전달)
+            let writeVC = WriteVC()
+            print("고민상세", self.worryDetail)
+            writeVC.modalPresentationStyle = .fullScreen
+            writeVC.modalTransitionStyle = .coverVertical
+            self.present(writeVC,animated: true)
+        }
+        
+        editDeadlineButton.press {
+            //TODO: 데드라인 수정하기 -> 기존 데드라인 표시
+            let pickerVC = WritePickerVC()
+            print("디데이", self.worryDetail?.dDay)
+            pickerVC.modalPresentationStyle = .fullScreen
+            pickerVC.modalTransitionStyle = .coverVertical
+            self.present(pickerVC, animated: true)
+        }
+        
+        deleteWorryButton.press {
+            //TODO: 고민 삭제 알럿
+        }
+        
+        cancelButton.press {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.dismiss(animated: true, completion: nil)
+            })
+        }
+    }
+}
+
+// MARK: - UI
+extension HomeWorryEditVC {
+    private func setUI() {
+        view.backgroundColor = UIColor(white: 0, alpha: 0.5)
+        
+        view.addSubViews([menuStackView, cancelButton])
+        
+        menuStackView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(80)
+            $0.height.equalTo(156.adjustedH)
+            $0.width.equalTo(342.adjustedW)
+        }
+        
+        menuStackView.addArrangedSubviews([editWorryButton, editDeadlineButton, deleteWorryButton])
+        
+        
+        cancelButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(52)
+            $0.width.equalTo(menuStackView.snp.width)
+        }
+    }
+}

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
@@ -16,7 +16,8 @@ final class HomeWorryDetailViewModel: ViewModelType {
     
     private let output: PassthroughSubject<WorryDetailModel, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
-    private var worryId = 1
+    
+    var worryDetail: WorryDetailModel?
     
     // MARK: - Function
     func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<WorryDetailModel, Never> {
@@ -37,6 +38,7 @@ extension HomeWorryDetailViewModel {
             guard let res = res else { return }
             guard let data = res.data else { return }
             self.output.send(data)
+            self.worryDetail = data
         }
     }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- 고민 상세 뷰 우 상단에 편집버튼 클릭시 보여지는 편집메뉴 뷰를 구현하였습니다.
- 고민 수정하기, 데드라인 수정하기에 필요한 데이터를 전달하기 위해 고민 상세 뷰모델에 고민 내용을 담고 있는 worryDetailModel 프로퍼티를 추가하여 서버에서 받은 데이터를 가지도록 하였습니다.

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- MVVM 패턴을 사용하기 때문에 원래 homeWorryDetailViewModel에서 EdtiVC의 뷰모델로 데이터를 전달하는게 맞는것 같으나 단순히 worryDetailModel하나를 전달하기 위해 뷰모델을 새로 만드는게 너무 비효율 적인것 같아 그냥 직관적으로 VC를 통해 데이터를 전달하도록 했습니다.
- 고민 편집 메뉴에서 '고민 수정하기', '데드라인 수정' 부분은 @oy6uns 가 담당한 뷰로 연결이 되야하므로 일단 HomeWorryEditVC까지만 데이터를 전달해 놓았고 이후 수정 메뉴를 통한 뷰 전환은 @oy6uns 가 담당해야 해줘야 할 것 같습니다! 
  - 고민 수정을 통해 writeVC 진입시 고민 상세에 있던 내용이 각 textView에 입력이 되어 있어야하고 '완료' 버튼 대신, '수정' 버튼이라고 표시 + '수정'클릭시 데드라인 설정 뷰는 안띄우기 등
  - 피그마 flow 스토리보드에 제가 만든 부분을 참고해 구현해주시면 좋을 것 같습니다!

+ 다음 PR에서 고민 삭제하기 알림창 구현 예정인데 해당 PR작업시 HomeWorryEditVC 수정 예정이므로 다음 PR 머지할때 까지는 HomeWorryEditVC 수정 안해주시는게 좋을 것 같습니다~

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-09-12 at 21 17 30](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/f4225f25-f874-4a57-9da4-8a4d9f77732d)


## 🚨 관련 이슈
- Resolved: #54


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
