### PR TITLE
[Feat] 고민보관함 뷰에서 고민 클릭시 상세보기 뷰로 가는 로직 구현

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -40,9 +40,9 @@ class ArchiveVC: UIViewController, RefreshListDelegate {
     
     // MARK: - Constants
     final let worryListInset: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16.adjustedW, bottom: 20, right: 16.adjustedW)
-    final let interItemSpacing: CGFloat = 12.adjustedW
-    final let lineSpacing: CGFloat = 12.adjustedW
-    let worryCellCize = CGSize(width: 165.adjustedW, height: 165.adjustedW)
+    final let interItemSpacing: CGFloat = 11.adjustedW
+    final let lineSpacing: CGFloat = 11.adjustedW
+    let worryCellCize = CGSize(width: 166.adjustedW, height: 166.adjustedW)
     
     // MARK: - Life Cycles
     override func viewDidLoad() {
@@ -157,6 +157,14 @@ extension ArchiveVC: UICollectionViewDataSource {
                 as? WorryListCVC else { return UICollectionViewCell() }
         cell.dataBind(model: worryListWithTemplate[indexPath.item])
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("indexPath?: ", indexPath.row)
+        let worryDetailVC = HomeWorryDetailVC(worryId: worryListWithTemplate[indexPath.row].worryId, type: .dug)
+        worryDetailVC.modalPresentationStyle = .overFullScreen
+        worryDetailVC.modalTransitionStyle = .coverVertical
+        self.present(worryDetailVC, animated: true)
     }
 }
 

--- a/KAERA/KAERA/Scenes/Archive/View/WorryListCVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/WorryListCVC.swift
@@ -37,6 +37,8 @@ class WorryListCVC: UICollectionViewCell {
         $0.text = "2023.02.10~2023.04.01"
         $0.font = .kSb1R12
         $0.textColor = .kGray4
+        /// figma에는 -6.5%로 나와있는데, 티가 잘 안나서 임의로 -50%로 설정해놨습니다
+        $0.setCharacterSpacing(-0.5)
     }
     
     override init(frame: CGRect) {

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -37,7 +37,7 @@ class WorryListViewModel: ViewModelType {
         worryUpdateList = []
         data.forEach {
             guard let imgName = IdtoImgDict[$0.templateId] else { return }
-            worryUpdateList.append(WorryListPublisherModel(templateId: $0.templateId, title: $0.title, period: $0.period, image: UIImage(named: imgName) ?? UIImage() ))
+            worryUpdateList.append(WorryListPublisherModel(worryId: $0.worryId, templateId: $0.templateId, title: $0.title, period: $0.period, image: UIImage(named: imgName) ?? UIImage() ))
         }
         self.output.send(worryUpdateList)
     }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailHeaderView.swift
@@ -34,18 +34,18 @@ final class HomeWorryDetailHeaderView: UITableViewHeaderFooterView {
     }
     
     private let gemStoneDictionary: [DictionaryKey : String] = [
-        DictionaryKey(templateId: 1, type: .digging) : "gemstone_pink",
-        DictionaryKey(templateId: 2, type: .digging) : "gemstone_orange",
-        DictionaryKey(templateId: 3, type: .digging) : "gemstone_blue",
+        DictionaryKey(templateId: 1, type: .digging) : "gemstone_blue",
+        DictionaryKey(templateId: 2, type: .digging) : "gemstone_red",
+        DictionaryKey(templateId: 3, type: .digging) : "gemstone_orange",
         DictionaryKey(templateId: 4, type: .digging) : "gemstone_green",
-        DictionaryKey(templateId: 5, type: .digging) : "gemstone_yellow",
-        DictionaryKey(templateId: 6, type: .digging) : "gemstone_red",
-        DictionaryKey(templateId: 1, type: .dug) : "gem_pink_l",
-        DictionaryKey(templateId: 2, type: .dug) : "gem_orange_l",
-        DictionaryKey(templateId: 3, type: .dug) : "gem_blue_l",
+        DictionaryKey(templateId: 5, type: .digging) : "gemstone_pink",
+        DictionaryKey(templateId: 6, type: .digging) : "gemstone_yellow",
+        DictionaryKey(templateId: 1, type: .dug) : "gem_blue_l",
+        DictionaryKey(templateId: 2, type: .dug) : "gem_red_l",
+        DictionaryKey(templateId: 3, type: .dug) : "gem_orange_l",
         DictionaryKey(templateId: 4, type: .dug) : "gem_green_l",
-        DictionaryKey(templateId: 5, type: .dug) : "gem_yellow_l",
-        DictionaryKey(templateId: 6, type: .dug) : "gem_red_l"
+        DictionaryKey(templateId: 5, type: .dug) : "gem_pink_l",
+        DictionaryKey(templateId: 6, type: .dug) : "gem_yellow_l"
     ]
     
     

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeGemListViewModel.swift
@@ -32,20 +32,20 @@ final class HomeGemListViewModel: ViewModelType {
         let id: Int
         let isSolved: Int
     }
-    
+
     private var gemStoneDictionary: [TemplateKey: String] = [
-        TemplateKey(id: 1, isSolved: 0): "gemstone_pink",
-        TemplateKey(id: 1, isSolved: 1): "gem_pink_l",
-        TemplateKey(id: 2, isSolved: 0): "gemstone_orange",
-        TemplateKey(id: 2, isSolved: 1): "gem_orange_l",
-        TemplateKey(id: 3, isSolved: 0): "gemstone_blue",
-        TemplateKey(id: 3, isSolved: 1): "gem_blue_l",
+        TemplateKey(id: 1, isSolved: 0): "gemstone_blue",
+        TemplateKey(id: 1, isSolved: 1): "gem_blue_l",
+        TemplateKey(id: 2, isSolved: 0): "gemstone_red",
+        TemplateKey(id: 2, isSolved: 1): "gem_red_l",
+        TemplateKey(id: 3, isSolved: 0): "gemstone_orange",
+        TemplateKey(id: 3, isSolved: 1): "gem_orange_l",
         TemplateKey(id: 4, isSolved: 0): "gemstone_green",
         TemplateKey(id: 4, isSolved: 1): "gem_green_l",
-        TemplateKey(id: 5, isSolved: 0): "gemstone_yellow",
-        TemplateKey(id: 5, isSolved: 1): "gem_yellow_l",
-        TemplateKey(id: 6, isSolved: 0): "gemstone_red",
-        TemplateKey(id: 6, isSolved: 1): "gem_red_l",
+        TemplateKey(id: 5, isSolved: 0): "gemstone_pink",
+        TemplateKey(id: 5, isSolved: 1): "gem_pink_l",
+        TemplateKey(id: 6, isSolved: 0): "gemstone_yellow",
+        TemplateKey(id: 6, isSolved: 1): "gem_yellow_l",
     ]
     
     private var gemStoneList: [HomePublisherModel] = []

--- a/KAERA/KAERA/Scenes/Writing/Model/WorryListModel.swift
+++ b/KAERA/KAERA/Scenes/Writing/Model/WorryListModel.swift
@@ -23,6 +23,7 @@ struct Worry: Codable {
 
 // View에 뿌려주기 위한 model
 struct WorryListPublisherModel {
+    let worryId: Int
     let templateId: Int
     let title: String
     let period: String


### PR DESCRIPTION
## 💪 작업한 내용
- 고민보관함 뷰에서 고민 클릭시 그에 해당하는 고민상세뷰가 modal될 수 있도록 구현했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- worryListPublisherModel에 worryId가 빠져 있어서 따로 추가해주었습니다. 
- 고민상세뷰 init시에 클릭한 고민의 worryId를 전달해주었습니다. 
- 홈뷰와 고민상세뷰의 gemStoneDictionary의 보석 이미지 순서가 피그마와 달라 알맞게 조정해주었습니다. (사실 여기서 하면 안될거 같긴한데,,,ㅎㅎ 그냥 색깔놀이라서 후딱했습니당)


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-09-24 at 16 35 59](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/1ca1dbff-7502-47a8-9ebc-9a59adb4e363)


## 🚨 관련 이슈
- Resolved: #59 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
