### PR TITLE
[Feat] 고민작성 API 연결

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		85A8492F2A87A9EC009F1468 /* TemplateContentTV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */; };
 		85A849312A87A9F7009F1468 /* TemplateContentTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */; };
 		85A849332A87DA36009F1468 /* TemplateContentHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */; };
+		85E349492AC06C63007D9956 /* ContentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E349482AC06C63007D9956 /* ContentInfo.swift */; };
 		85EBC7F12A5AD7BC00B9E891 /* KaeraTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F02A5AD7BC00B9E891 /* KaeraTabbarController.swift */; };
 		85EBC7F32A5AD93200B9E891 /* HomeGemStoneVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */; };
 		85EBC7F52A5AD94100B9E891 /* WriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F42A5AD94100B9E891 /* WriteVC.swift */; };
@@ -117,6 +118,7 @@
 		85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentTV.swift; sourceTree = "<group>"; };
 		85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentTVC.swift; sourceTree = "<group>"; };
 		85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentHeaderView.swift; sourceTree = "<group>"; };
+		85E349482AC06C63007D9956 /* ContentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentInfo.swift; sourceTree = "<group>"; };
 		85EBC7F02A5AD7BC00B9E891 /* KaeraTabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KaeraTabbarController.swift; sourceTree = "<group>"; };
 		85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemStoneVC.swift; sourceTree = "<group>"; };
 		85EBC7F42A5AD94100B9E891 /* WriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteVC.swift; sourceTree = "<group>"; };
@@ -532,6 +534,7 @@
 		E7BB4F4C2A5EF7520018312B /* View */ = {
 			isa = PBXGroup;
 			children = (
+				85E349482AC06C63007D9956 /* ContentInfo.swift */,
 				85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */,
 				85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */,
 				85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */,
@@ -747,6 +750,7 @@
 				E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */,
 				E79AAC352A52F2C300F3F439 /* UIImageView+.swift in Sources */,
 				85887D9C2A605D0B00F7FB21 /* TemplateInfoVC.swift in Sources */,
+				85E349492AC06C63007D9956 /* ContentInfo.swift in Sources */,
 				E7BB4F4F2A5EF81C0018312B /* WorryListViewModel.swift in Sources */,
 				E7FEC09E2A6F6C76006F36BF /* ViewModelType.swift in Sources */,
 			);

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -21,7 +21,7 @@ final class WriteAPI {
     
     public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?
     public private(set) var templateContentResponse: GeneralResponse<TemplateContentModel>?
-    public private(set) var woryContentResponse: GeneralResponse<WorryContentResponseDto>?
+    public private(set) var woryContentResponse: GeneralResponse<WorryContentResponseModel>?
     
     
     // MARK: - HomeGemList
@@ -65,13 +65,13 @@ final class WriteAPI {
         }
     }
     
-    func postWorryContent(param: WorryContentRequestDto, completion: @escaping (GeneralResponse<WorryContentResponseDto>?) -> () ) {
+    func postWorryContent(param: WorryContentRequestModel, completion: @escaping (GeneralResponse<WorryContentResponseModel>?) -> () ) {
         writeProvider.request(.postWorryContent(param: param)) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
                     self?.woryContentResponse = try
-                    result.map(GeneralResponse<WorryContentResponseDto>?.self)
+                    result.map(GeneralResponse<WorryContentResponseModel>?.self)
                     guard let contentList = self?.woryContentResponse else { return }
                     completion(contentList)
                 } catch(let err) {

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -14,10 +14,14 @@ final class WriteAPI {
     static let shared: WriteAPI = WriteAPI()
     private let writeProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
     
+    // tableView의 데이터들을 담는 싱글톤 클래스
+    let contentInfo = ContentInfo.shared
+    
     private init() { }
     
     public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?
     public private(set) var templateContentResponse: GeneralResponse<TemplateContentModel>?
+    public private(set) var woryContentResponse: GeneralResponse<WorryContentResponseDto>?
     
     
     // MARK: - HomeGemList
@@ -49,6 +53,26 @@ final class WriteAPI {
                     self?.templateContentResponse = try
                     result.map(GeneralResponse<TemplateContentModel>?.self)
                     guard let contentList = self?.templateContentResponse else { return }
+                    completion(contentList)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func postWorryContent(param: WorryContentRequestDto, completion: @escaping (GeneralResponse<WorryContentResponseDto>?) -> () ) {
+        writeProvider.request(.postWorryContent(param: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.woryContentResponse = try
+                    result.map(GeneralResponse<WorryContentResponseDto>?.self)
+                    guard let contentList = self?.woryContentResponse else { return }
                     completion(contentList)
                 } catch(let err) {
                     print(err.localizedDescription)

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -13,7 +13,7 @@ import Moya
 enum WriteService {
     case getTemplateList
     case getTemplateQuestion(templateId: Int)
-    case postWorryContent(param: WorryContentRequestDto)
+    case postWorryContent(param: WorryContentRequestModel)
 }
 
 extension WriteService: BaseTargetType {
@@ -42,7 +42,7 @@ extension WriteService: BaseTargetType {
         switch self {
         case .getTemplateList, .getTemplateQuestion:
             return .requestPlain
-        case .postWorryContent(param: let param):
+        case .postWorryContent(let param):
             return .requestJSONEncodable(param)
         }
     }

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -6,11 +6,14 @@
 //
 
 import Foundation
+import UIKit
+
 import Moya
 
 enum WriteService {
     case getTemplateList
     case getTemplateQuestion(templateId: Int)
+    case postWorryContent(param: WorryContentRequestDto)
 }
 
 extension WriteService: BaseTargetType {
@@ -21,6 +24,8 @@ extension WriteService: BaseTargetType {
             return APIConstant.template
         case .getTemplateQuestion(let templateId):
             return APIConstant.template + "/\(templateId)"
+        case .postWorryContent:
+            return APIConstant.worry
         }
     }
     
@@ -28,6 +33,8 @@ extension WriteService: BaseTargetType {
         switch self {
         case .getTemplateList, .getTemplateQuestion:
             return .get
+        case .postWorryContent:
+            return .post
         }
     }
     
@@ -35,6 +42,8 @@ extension WriteService: BaseTargetType {
         switch self {
         case .getTemplateList, .getTemplateQuestion:
             return .requestPlain
+        case .postWorryContent(param: let param):
+            return .requestJSONEncodable(param)
         }
     }
 
@@ -43,6 +52,8 @@ extension WriteService: BaseTargetType {
         case .getTemplateList:
             return NetworkConstant.hasTokenHeader
         case .getTemplateQuestion:
+            return NetworkConstant.hasTokenHeader
+        case .postWorryContent:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -14,3 +14,16 @@ struct TemplateContentModel: Codable {
     let questions: [String]
     let hints: [String]
 }
+
+/// 서버 post용 모델
+struct WorryContentRequestDto: Codable {
+    var templateId: Int
+    var title: String
+    var answers: [String]
+    var deadline: Int
+}
+
+struct WorryContentResponseDto: Codable {
+    let createdAt: String
+    let deadline: String
+}

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -16,14 +16,14 @@ struct TemplateContentModel: Codable {
 }
 
 /// 서버 post용 모델
-struct WorryContentRequestDto: Codable {
+struct WorryContentRequestModel: Codable {
     var templateId: Int
     var title: String
     var answers: [String]
     var deadline: Int
 }
 
-struct WorryContentResponseDto: Codable {
+struct WorryContentResponseModel: Codable {
     let createdAt: String
     let deadline: String
 }

--- a/KAERA/KAERA/Scenes/Writing/View/ContentInfo.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/ContentInfo.swift
@@ -10,10 +10,10 @@ import Foundation
 class ContentInfo {
     static let shared = ContentInfo()
 
-    var templateId: Int?
-    var title: String?
-    var answers: [String]?
-    var deadline: Int?
+    var templateId: Int = 1
+    var title: String = ""
+    var answers: [String] = []
+    var deadline: Int = -1
 
     private init() { }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/ContentInfo.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/ContentInfo.swift
@@ -1,0 +1,19 @@
+//
+//  ContentInfo.swift
+//  KAERA
+//
+//  Created by saint on 2023/09/24.
+//
+
+import Foundation
+
+class ContentInfo {
+    static let shared = ContentInfo()
+
+    var templateId: Int?
+    var title: String?
+    var answers: [String]?
+    var deadline: Int?
+
+    private init() { }
+}

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -9,9 +9,15 @@ import UIKit
 import SnapKit
 import Then
 
+protocol TemplateContentHeaderViewDelegate: AnyObject {
+    func textFieldDidEndEditing(view: TemplateContentHeaderView, newText: String)
+}
+
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
     
     // MARK: - Properties
+    weak var delegate: TemplateContentHeaderViewDelegate?
+    
     let worryTitleTextField = UITextField().then{
         $0.layer.cornerRadius = 8
         $0.backgroundColor = .clear
@@ -98,6 +104,10 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
         let attributedString = NSMutableAttributedString(string: "\(worryTitleTextField.text!.count)/7")
         attributedString.addAttribute(.foregroundColor, value: UIColor.kWhite, range: ("\(worryTitleTextField.text!.count)/7" as NSString).range(of:"\(worryTitleTextField.text!.count)"))
         titleNumLabel.attributedText = attributedString
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
+        delegate?.textFieldDidEndEditing(view: self, newText: worryTitleTextField.text ?? "")
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentHeaderViewDelegate: AnyObject {
-    func textFieldDidEndEditing(view: TemplateContentHeaderView, newText: String)
+    func textFieldDidEndEditing(newText: String)
 }
 
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
@@ -107,7 +107,7 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-        delegate?.textFieldDidEndEditing(view: self, newText: worryTitleTextField.text ?? "")
+        delegate?.textFieldDidEndEditing(newText: worryTitleTextField.text ?? "")
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -98,7 +98,7 @@ extension TemplateContentTV : UITableViewDataSource
     }
 }
 
-extension TemplateContentTV: TemplateContentHeaderViewDelegate,  TemplateContentTVCDelegate {
+extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
     func textFieldDidEndEditing(view: TemplateContentHeaderView, newText: String) {
         contentInfo.title = newText
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -17,6 +17,8 @@ class TemplateContentTV: UITableView {
     var questions: [String] = []
     var hints: [String] = []
     
+    let contentInfo = ContentInfo.shared
+    
     // MARK: - Life Cycle
     init() {
         super.init(frame: .zero, style: .grouped)
@@ -73,6 +75,10 @@ extension TemplateContentTV : UITableViewDataSource
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
         headerCell.worryTitleTextField.becomeFirstResponder()
+
+        /// headerCell에 입력된 고민 제목을 contentInfo에 담아준다. 
+        headerCell.delegate = self
+        
         return headerCell
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -14,8 +14,9 @@ class TemplateContentTV: UITableView {
     
     // MARK: - Properties
     var templateId: Int = 0
-    var questions: [String] = []
-    var hints: [String] = []
+    private var questions: [String] = []
+    private var hints: [String] = []
+    private var answers: [String] = []
     
     let contentInfo = ContentInfo.shared
     
@@ -32,6 +33,12 @@ class TemplateContentTV: UITableView {
     }
     
     // MARK: - Functions
+    func setData(questions: [String], hints: [String]) {
+        self.questions = questions
+        self.hints = hints
+        self.answers = Array(repeating: "", count: hints.count)
+    }
+    
     private func registerTV() {
         self.register(TemplateContentTVC.self,
                       forCellReuseIdentifier: TemplateContentTVC.classIdentifier)
@@ -92,23 +99,22 @@ extension TemplateContentTV : UITableViewDataSource
         /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
         cell.delegate = self
         
-        cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row])
+        cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], index: indexPath.row)
         
         return cell
     }
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    func textFieldDidEndEditing(newText: String) {
-        contentInfo.title = newText
+    
+
+    
+    func textViewDidEndEditing(index: Int, newText: String) {
+        answers[index] = newText
+        contentInfo.answers = answers
     }
     
-    func textViewDidEndEditing(cell: TemplateContentTVC, newText: String) {
-
-        if let indexPath = indexPath(for: cell) {
-            /// 각 cell의 힌트를 작성된 텍스트로 변경하여 contentInfo에 담아준다.
-            hints[indexPath.row] = newText
-            contentInfo.answers = hints
-        }
+    func textFieldDidEndEditing(newText: String) {
+        contentInfo.title = newText
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -91,3 +91,18 @@ extension TemplateContentTV : UITableViewDataSource
         return cell
     }
 }
+
+extension TemplateContentTV: TemplateContentHeaderViewDelegate,  TemplateContentTVCDelegate {
+    func textFieldDidEndEditing(view: TemplateContentHeaderView, newText: String) {
+        contentInfo.title = newText
+    }
+    
+    func textViewDidEndEditing(cell: TemplateContentTVC, newText: String) {
+
+        if let indexPath = indexPath(for: cell) {
+            /// 각 cell의 힌트를 작성된 텍스트로 변경하여 contentInfo에 담아준다.
+            hints[indexPath.row] = newText
+            contentInfo.answers = hints
+        }
+    }
+}

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -99,7 +99,7 @@ extension TemplateContentTV : UITableViewDataSource
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    func textFieldDidEndEditing(view: TemplateContentHeaderView, newText: String) {
+    func textFieldDidEndEditing(newText: String) {
         contentInfo.title = newText
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -76,7 +76,7 @@ extension TemplateContentTV : UITableViewDataSource
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
         headerCell.worryTitleTextField.becomeFirstResponder()
 
-        /// headerCell에 입력된 고민 제목을 contentInfo에 담아준다. 
+        /// headerCell에 입력된 고민 제목을 contentInfo에 담아준다.
         headerCell.delegate = self
         
         return headerCell

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -86,6 +86,12 @@ extension TemplateContentTV : UITableViewDataSource
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TemplateContentTVC.classIdentifier, for: indexPath) as? TemplateContentTVC else {return UITableViewCell()}
         
+        /// 1씩 작은 templateId에 1을 더해주어 원래 값으로 만들어준다.
+        contentInfo.templateId = templateId + 1
+        
+        /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
+        cell.delegate = self
+        
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row])
         
         return cell

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -10,13 +10,15 @@ import SnapKit
 import Then
 
 protocol TemplateContentTVCDelegate: AnyObject {
-    func textViewDidEndEditing(cell: TemplateContentTVC, newText: String)
+    func textViewDidEndEditing(index: Int, newText: String)
 }
 
 class TemplateContentTVC: UITableViewCell {
     
     // MARK: - Properties
     weak var delegate: TemplateContentTVCDelegate?
+    
+    private var indexPath: Int = 0
     
     private var keyboardHeight: CGFloat = 336.adjustedH
     
@@ -29,8 +31,8 @@ class TemplateContentTVC: UITableViewCell {
     
     private let textViewConstant: CGFloat = 111.adjustedH
     
-    var placeHolder: String = ""
-    
+    private var placeHolder: String = ""
+        
     lazy var textView = UITextView().then {
         $0.isScrollEnabled = false
         $0.delegate = self
@@ -73,11 +75,12 @@ class TemplateContentTVC: UITableViewCell {
         }
     }
     
-    func dataBind(question: String, hint: String) {
+    func dataBind(question: String, hint: String, index: Int) {
         questionLabel.text = question
         /// 아래의 textViewDelegate에서 update된 placeholder를 써주기 위해 placeholder에도 hint를 담아준다.
         placeHolder = hint
         textView.text = placeHolder
+        self.indexPath = index
     }
 }
 
@@ -145,6 +148,6 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.endUpdates()
         }
         
-        delegate?.textViewDidEndEditing(cell: self, newText: trimmedText)
+        delegate?.textViewDidEndEditing(index: self.indexPath, newText: trimmedText)
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -9,9 +9,15 @@ import UIKit
 import SnapKit
 import Then
 
+protocol TemplateContentTVCDelegate: AnyObject {
+    func textViewDidEndEditing(cell: TemplateContentTVC, newText: String)
+}
+
 class TemplateContentTVC: UITableViewCell {
     
     // MARK: - Properties
+    weak var delegate: TemplateContentTVCDelegate?
+    
     private var keyboardHeight: CGFloat = 336.adjustedH
     
     private var questionLabel = UILabel().then {
@@ -138,5 +144,7 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
+        
+        delegate?.textViewDidEndEditing(cell: self, newText: trimmedText)
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -86,23 +86,24 @@ class WritePickerVC: UIViewController {
     
     // MARK: - Functions
     private func pressBtn() {
-        /// picker에서 고른 숫자를 deadline으로 설정해줌.
-        let selectedRow = datePickerView.selectedRow(inComponent: 0)
-        let selectedValue = pickerData[selectedRow]
-        contentInfo.deadline = Int(selectedValue)
         
-        /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
-        publishedContent.templateId = contentInfo.templateId ?? 1
-        publishedContent.title = contentInfo.title ?? ""
-        publishedContent.answers = contentInfo.answers ?? []
-        publishedContent.deadline = contentInfo.deadline ?? -1
-        
-        /// 서버로 고민 내용을 POST 시켜줌
-        WriteAPI.shared.postWorryContent(param: publishedContent) { result in
-            guard let result = result, let _ = result.data else { return }
-        }
-        
-        completeWritingBtn.press {[self] in
+        completeWritingBtn.press { [self] in
+            /// picker에서 고른 숫자를 deadline으로 설정해줌.
+            let selectedRow = datePickerView.selectedRow(inComponent: 0)
+            let selectedValue = pickerData[selectedRow]
+            contentInfo.deadline = Int(selectedValue)
+                        
+            /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
+            publishedContent.templateId = contentInfo.templateId ?? 1
+            publishedContent.title = contentInfo.title ?? ""
+            publishedContent.answers = contentInfo.answers ?? []
+            publishedContent.deadline = contentInfo.deadline ?? -1
+            
+            /// 서버로 고민 내용을 POST 시켜줌
+            WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+                guard let result = result, let _ = result.data else { return }
+            }
+            
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
                 view.layoutIfNeeded()

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -91,13 +91,13 @@ class WritePickerVC: UIViewController {
             /// picker에서 고른 숫자를 deadline으로 설정해줌.
             let selectedRow = datePickerView.selectedRow(inComponent: 0)
             let selectedValue = pickerData[selectedRow]
-            contentInfo.deadline = Int(selectedValue)
+            contentInfo.deadline = Int(selectedValue) ?? -1
                         
             /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
-            publishedContent.templateId = contentInfo.templateId ?? 1
-            publishedContent.title = contentInfo.title ?? ""
-            publishedContent.answers = contentInfo.answers ?? []
-            publishedContent.deadline = contentInfo.deadline ?? -1
+            publishedContent.templateId = contentInfo.templateId
+            publishedContent.title = contentInfo.title
+            publishedContent.answers = contentInfo.answers
+            publishedContent.deadline = contentInfo.deadline
             
             /// 서버로 고민 내용을 POST 시켜줌
             WriteAPI.shared.postWorryContent(param: publishedContent) { result in

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -86,6 +86,22 @@ class WritePickerVC: UIViewController {
     
     // MARK: - Functions
     private func pressBtn() {
+        /// picker에서 고른 숫자를 deadline으로 설정해줌.
+        let selectedRow = datePickerView.selectedRow(inComponent: 0)
+        let selectedValue = pickerData[selectedRow]
+        contentInfo.deadline = Int(selectedValue)
+        
+        /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
+        publishedContent.templateId = contentInfo.templateId ?? 1
+        publishedContent.title = contentInfo.title ?? ""
+        publishedContent.answers = contentInfo.answers ?? []
+        publishedContent.deadline = contentInfo.deadline ?? -1
+        
+        /// 서버로 고민 내용을 POST 시켜줌
+        WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+            guard let result = result, let _ = result.data else { return }
+        }
+        
         completeWritingBtn.press {[self] in
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
@@ -95,22 +111,6 @@ class WritePickerVC: UIViewController {
                     NotificationCenter.default.post(name: NSNotification.Name("CompleteWriting"), object: nil, userInfo: nil)
                 })
             })
-            
-            /// picker에서 고른 숫자를 deadline으로 설정해줌.
-            let selectedRow = datePickerView.selectedRow(inComponent: 0)
-            let selectedValue = pickerData[selectedRow]
-            contentInfo.deadline = Int(selectedValue)
-            
-            /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
-            publishedContent.templateId = contentInfo.templateId ?? 1
-            publishedContent.title = contentInfo.title ?? ""
-            publishedContent.answers = contentInfo.answers ?? []
-            publishedContent.deadline = contentInfo.deadline ?? -1
-                        
-            /// 서버로 고민 내용을 POST 시켜줌
-            WriteAPI.shared.postWorryContent(param: publishedContent) { result in
-                guard let result = result, let _ = result.data else { return }
-            }
         }
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -18,6 +18,8 @@ class WritePickerVC: UIViewController {
         $0.backgroundColor = .kGray1
     }
     
+    let contentInfo = ContentInfo.shared
+    
     private let pickerViewTitle = UILabel().then {
         $0.text = "이 고민, 언제까지 끝낼까요?"
         $0.font = .kB1B16
@@ -83,7 +85,7 @@ class WritePickerVC: UIViewController {
     
     // MARK: - Functions
     private func pressBtn() {
-        completeWritingBtn.press {
+        completeWritingBtn.press {[self] in
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
                 view.layoutIfNeeded()
@@ -92,7 +94,15 @@ class WritePickerVC: UIViewController {
                     NotificationCenter.default.post(name: NSNotification.Name("CompleteWriting"), object: nil, userInfo: nil)
                 })
             })
-        }
+            
+            let selectedRow = datePickerView.selectedRow(inComponent: 0)
+            let selectedValue = pickerData[selectedRow]
+            contentInfo.deadline = Int(selectedValue)
+            print("Template ID: \(contentInfo.templateId ?? 0)")
+            print("Title: \(contentInfo.title ?? "")")
+            print("Answers: \(contentInfo.answers ?? [])")
+            print("Deadline: \(contentInfo.deadline ?? 0)")
+            }
     }
     
     private func setDelegate() {

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -19,7 +19,7 @@ class WritePickerVC: UIViewController {
     }
     
     let contentInfo = ContentInfo.shared
-    var publishedContent = WorryContentRequestDto(templateId: 1, title: "", answers: [], deadline: -1)
+    var publishedContent = WorryContentRequestModel(templateId: 1, title: "", answers: [], deadline: -1)
     
     private let pickerViewTitle = UILabel().then {
         $0.text = "이 고민, 언제까지 끝낼까요?"
@@ -99,10 +99,7 @@ class WritePickerVC: UIViewController {
             publishedContent.answers = contentInfo.answers
             publishedContent.deadline = contentInfo.deadline
             
-            /// 서버로 고민 내용을 POST 시켜줌
-            WriteAPI.shared.postWorryContent(param: publishedContent) { result in
-                guard let result = result, let _ = result.data else { return }
-            }
+            self.postWorryContent()
             
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
@@ -118,6 +115,13 @@ class WritePickerVC: UIViewController {
     private func setDelegate() {
         datePickerView.delegate = self
         datePickerView.dataSource = self
+    }
+    
+    private func postWorryContent() {
+        /// 서버로 고민 내용을 POST 시켜줌
+        WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+            guard let result = result, let _ = result.data else { return }
+        }
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -19,6 +19,7 @@ class WritePickerVC: UIViewController {
     }
     
     let contentInfo = ContentInfo.shared
+    var publishedContent = WorryContentRequestDto(templateId: 1, title: "", answers: [], deadline: -1)
     
     private let pickerViewTitle = UILabel().then {
         $0.text = "이 고민, 언제까지 끝낼까요?"
@@ -95,14 +96,22 @@ class WritePickerVC: UIViewController {
                 })
             })
             
+            /// picker에서 고른 숫자를 deadline으로 설정해줌.
             let selectedRow = datePickerView.selectedRow(inComponent: 0)
             let selectedValue = pickerData[selectedRow]
             contentInfo.deadline = Int(selectedValue)
-            print("Template ID: \(contentInfo.templateId ?? 0)")
-            print("Title: \(contentInfo.title ?? "")")
-            print("Answers: \(contentInfo.answers ?? [])")
-            print("Deadline: \(contentInfo.deadline ?? 0)")
+            
+            /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
+            publishedContent.templateId = contentInfo.templateId ?? 1
+            publishedContent.title = contentInfo.title ?? ""
+            publishedContent.answers = contentInfo.answers ?? []
+            publishedContent.deadline = contentInfo.deadline ?? -1
+                        
+            /// 서버로 고민 내용을 POST 시켜줌
+            WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+                guard let result = result, let _ = result.data else { return }
             }
+        }
     }
     
     private func setDelegate() {

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -90,6 +90,9 @@ class WriteVC: BaseVC {
         $0.font = .kSb1R12
     }
     
+    /// tableView의 데이터들을 담는 싱글톤 클래스
+    let contentInfo = ContentInfo.shared
+
     private let pickerVC = WritePickerVC()
     
     // MARK: - Life Cycles

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -92,7 +92,7 @@ class WriteVC: BaseVC {
     
     /// tableView의 데이터들을 담는 싱글톤 클래스
     let contentInfo = ContentInfo.shared
-
+    
     private let pickerVC = WritePickerVC()
     
     // MARK: - Life Cycles
@@ -105,6 +105,13 @@ class WriteVC: BaseVC {
         hideKeyboardWhenTappedAround()
         addKeyboardObserver()
         dataBind()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.didCompleteWritingNotification(_:)),
+            name: NSNotification.Name("CompleteWriting"),
+            object: nil
+        )
     }
     
     // MARK: - Functions

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -126,8 +126,7 @@ class WriteVC: BaseVC {
     }
     
     private func updateUI(_ templateContents: TemplateContentModel) {
-        templateContentTV.questions = templateContents.questions
-        templateContentTV.hints = templateContents.hints
+        templateContentTV.setData(questions: templateContents.questions, hints: templateContents.hints)
         
         view.addSubview(templateContentTV)
         templateContentTV.snp.updateConstraints {


### PR DESCRIPTION
## 💪 작업한 내용
- 고민작성 뷰에서 고민작성 완료 시에 서버와 통신하는 API를 연결하였습니다. 
- 고민제목, 템플릿 ID, 템플릿의 각 질문에 대한 답변 내용, 데드라인 일자를 담아 서버로 request 해줍니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 여러 VC에서 동일한 데이터를 공유해야 하기에 싱글톤 클래스를 선언하여 각 VC에서 데이터를 담아주었습니다. 
    - TemplateContentTV: templateId
    - TemplateContentTVC: answers
        ➡️ 각 TemplateContentTableViewCell에서 IndexPath를 TableView로 보내주어 원래 각 cell의 placeholder가 담겨 있는 hints라는 배열에서 전달받은 IndexPath와 동일한 index의 내용을 변환시켜주었습니다. 
        ➡️ 기존의 placeholder들을 담고 있는 hints배열을 서버로 보내주는 것이기 때문에, 사용자가 값을 따로 쓰지 않으면 placeholder값이 배열에 담겨 서버로 보내진다는 문제가 있긴한데, 이 점은 사용자가 값을 쓰지 않으면 완료 버튼이 안눌리는 알럿을 구현할 것이기 때문에 문제가 없을 것으로 보입니다. 
    - TemplateContentHeaderView: title
    - WritePickerVC: deadline
        ➡️ pickerView에서 선택한 숫자
- 싱글톤 클래스의 내용을 서버로 POST해주기 위해 동일한 내용을 담고 있는 WorryContentRequestDto 구조체를 선언하여 값을 동일하게 대응시켜주었습니다. 

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-09-26 at 10 50 30](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/fbca0b06-5182-4e13-9467-32341212f313)
<img width="758" alt="스크린샷 2023-09-26 오전 10 52 04" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/25ccc2da-8f0e-4d12-bce7-4dcca9630202">


## 🚨 관련 이슈
- Resolved: #61 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
