### PR TITLE
[Feat] 로그인 유저 정보 키체인 저장 구현

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		E70764692ABFF68800627AA7 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70764682ABFF68800627AA7 /* AuthAPI.swift */; };
 		E707646E2ABFF7E800627AA7 /* SignInModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E707646D2ABFF7E800627AA7 /* SignInModel.swift */; };
 		E70764732ABFFF9200627AA7 /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70764722ABFFF9200627AA7 /* SignInViewModel.swift */; };
+		E70764752AC06B6000627AA7 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70764742AC06B6000627AA7 /* KeyChainManager.swift */; };
 		E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA02A90959A006B2E74 /* HomeService.swift */; };
 		E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA22A909829006B2E74 /* HomeAPI.swift */; };
 		E721EABD2A51D5D900A04AA0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E721EABC2A51D5D900A04AA0 /* Then */; };
@@ -133,6 +134,7 @@
 		E70764682ABFF68800627AA7 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
 		E707646D2ABFF7E800627AA7 /* SignInModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInModel.swift; sourceTree = "<group>"; };
 		E70764722ABFFF9200627AA7 /* SignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewModel.swift; sourceTree = "<group>"; };
+		E70764742AC06B6000627AA7 /* KeyChainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainManager.swift; sourceTree = "<group>"; };
 		E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		E70C7CA02A90959A006B2E74 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		E70C7CA22A909829006B2E74 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
@@ -332,6 +334,7 @@
 				E7A94CCC2AAC149900F231D0 /* Environment.swift */,
 				E7C808EA2A4D37F800F475CE /* SceneDelegate.swift */,
 				E7C808E82A4D37F800F475CE /* AppDelegate.swift */,
+				E70764742AC06B6000627AA7 /* KeyChainManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -729,6 +732,7 @@
 				E79AAC372A52F2C300F3F439 /* CALayer+.swift in Sources */,
 				E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */,
 				E7A94CCD2AAC149900F231D0 /* Environment.swift in Sources */,
+				E70764752AC06B6000627AA7 /* KeyChainManager.swift in Sources */,
 				E79AAC3D2A52F2C300F3F439 /* UIFont+.swift in Sources */,
 				85887D8E2A5D086300F7FB21 /* TemplateViewModel.swift in Sources */,
 				85ECEE4D2A9B821500A624AE /* WriteAPI.swift in Sources */,

--- a/KAERA/KAERA/Application/KeyChainManager.swift
+++ b/KAERA/KAERA/Application/KeyChainManager.swift
@@ -1,0 +1,128 @@
+//
+//  KeychainManager.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/09/24.
+//
+
+import Foundation
+
+enum UserInfoKey: String {
+    case userId
+    case userName
+    case acessToken
+    case refreshToken
+}
+
+struct UserInfoModel {
+    let userId: String?
+    let userName: String?
+    let accessToken: String?
+    let refreshToken: String?
+}
+
+final class KeychainManager {
+    
+    // Keychain에 값 저장하기
+    class func save(key: UserInfoKey, value: String) {
+        
+        guard let data = value.data(using: .utf8) else { return }
+        
+        let query = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+        ] as [String : Any]
+        
+        SecItemDelete(query as CFDictionary)
+        
+        let addQuery = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: data
+        ] as [String : Any]
+        
+        
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        
+        if status == errSecSuccess {
+            print("add \(key.rawValue) success")
+        } else if status == errSecDuplicateItem {
+            print("keychain already has \(key.rawValue)")
+        } else {
+            print("add \(key.rawValue) failed")
+        }
+    }
+    
+    // Keychain에서 값 가져오기
+    class func load(key: UserInfoKey) -> Data? {
+        let query = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ] as [String : Any]
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        if status == errSecSuccess {
+            return dataTypeRef as? Data
+        } else {
+            return nil
+        }
+    }
+    
+    // Keychain에서 값 삭제하기
+    class func delete(key: UserInfoKey) {
+        let query = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+        ] as [String : Any]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess {
+            // 아이템 삭제에 성공하면 동기화 작업을 수행
+            let syncStatus = SecItemUpdate(query as CFDictionary, [:] as CFDictionary)
+            
+            if syncStatus == errSecSuccess {
+                print("아이템이 완전히 삭제되었습니다.")
+            } else {
+                print("동기화에 실패하였습니다.")
+            }
+            print("delete \(key.rawValue) success")
+        } else {
+            print("delete \(key.rawValue) failed")
+        }
+    }
+    
+    // 사용자 정보 및 토큰 저장
+    static func saveUserInfo(id: String, userName: String, accessToken: String, refreshToken: String) {
+        KeychainManager.save(key: .userId, value: id)
+        KeychainManager.save(key: .userName, value: userName)
+        KeychainManager.save(key: .acessToken, value: accessToken)
+        KeychainManager.save(key: .refreshToken, value: refreshToken)
+    }
+    
+    // 사용자 정보 및 토큰 로드
+    static func loadUserInfo() -> UserInfoModel {
+        let userIdData = KeychainManager.load(key: .userId)
+        let userNameData = KeychainManager.load(key: .userName)
+        let accessTokenData = KeychainManager.load(key: .acessToken)
+        let refreshTokenData = KeychainManager.load(key: .refreshToken)
+        
+        let userId = String(data: userIdData ?? Data(), encoding: .utf8)
+        let userName = String(data: userNameData ?? Data(), encoding: .utf8)
+        let accessToken = String(data: accessTokenData ?? Data(), encoding: .utf8)
+        let refreshToken = String(data: refreshTokenData ?? Data(), encoding: .utf8)
+        
+        return UserInfoModel(userId: userId, userName: userName, accessToken: accessToken, refreshToken: refreshToken)
+    }
+    
+    static func clearAllUserInfo() {
+        KeychainManager.delete(key: .userId)
+        KeychainManager.delete(key: .userName)
+        KeychainManager.delete(key: .acessToken)
+        KeychainManager.delete(key: .refreshToken)
+    }
+    
+}

--- a/KAERA/KAERA/Application/KeyChainManager.swift
+++ b/KAERA/KAERA/Application/KeyChainManager.swift
@@ -54,7 +54,7 @@ final class KeychainManager {
     }
     
     // Keychain에서 값 가져오기
-    class func load(key: UserInfoKey) -> Data? {
+    class func load(key: UserInfoKey) -> String? {
         let query = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key.rawValue,
@@ -66,7 +66,9 @@ final class KeychainManager {
         let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
         
         if status == errSecSuccess {
-            return dataTypeRef as? Data
+            let dataString = String(data: dataTypeRef as? Data ?? Data(), encoding: .utf8)
+            return dataString
+            
         } else {
             return nil
         }
@@ -105,15 +107,10 @@ final class KeychainManager {
     
     // 사용자 정보 및 토큰 로드
     static func loadUserInfo() -> UserInfoModel {
-        let userIdData = KeychainManager.load(key: .userId)
-        let userNameData = KeychainManager.load(key: .userName)
-        let accessTokenData = KeychainManager.load(key: .acessToken)
-        let refreshTokenData = KeychainManager.load(key: .refreshToken)
-        
-        let userId = String(data: userIdData ?? Data(), encoding: .utf8)
-        let userName = String(data: userNameData ?? Data(), encoding: .utf8)
-        let accessToken = String(data: accessTokenData ?? Data(), encoding: .utf8)
-        let refreshToken = String(data: refreshTokenData ?? Data(), encoding: .utf8)
+        let userId = KeychainManager.load(key: .userId)
+        let userName = KeychainManager.load(key: .userName)
+        let accessToken = KeychainManager.load(key: .acessToken)
+        let refreshToken = KeychainManager.load(key: .refreshToken)
         
         return UserInfoModel(userId: userId, userName: userName, accessToken: accessToken, refreshToken: refreshToken)
     }

--- a/KAERA/KAERA/Network/Base/NetworkConstant.swift
+++ b/KAERA/KAERA/Network/Base/NetworkConstant.swift
@@ -22,4 +22,10 @@ struct NetworkConstant {
         return token
     }()
     
+    static let accessToken = {
+        guard let accessToken = KeychainManager.load(key: .acessToken) else {  fatalError("AccessToken Not in the Keychain")
+        }
+        return accessToken
+    }()
+    
 }

--- a/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
+++ b/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
@@ -55,7 +55,7 @@ final class SignInVC: UIViewController {
                 if isSucceed {
                     self?.moveToTabBarController()
                 }else {
-                    self?.presentAlertView()
+                    self?.makeAlert(title: "로그인에 실패했습니다 😢", message: "다시 한번 시도해주세요")
                 }
             }
             .store(in: &cancellables)
@@ -66,12 +66,6 @@ final class SignInVC: UIViewController {
         tabBar.modalTransitionStyle = .crossDissolve
         tabBar.modalPresentationStyle = .fullScreen
         self.present(tabBar, animated: true)
-    }
-    
-    private func presentAlertView() {
-        let alertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
-        alertVC.setTitleSubTitle(title: "로그인에 실패했습니다 😢", subTitle: "다시 한번 시도해주세요", highlighting: "")
-        self.present(alertVC, animated: true)
     }
     
     private func setLoginButtonAction() {

--- a/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
+++ b/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
@@ -51,12 +51,27 @@ final class SignInVC: UIViewController {
     private func dataBind() {
         let output = signinViewModel.transform(input: SignInViewModel.Input(input))
         output.receive(on: DispatchQueue.main)
-            .sink { [weak self] userInfo in
-                
-                /// user info 저장
-                KeychainManager.saveUserInfo(id: "\(userInfo.id)", userName: userInfo.name, accessToken: userInfo.accessToken, refreshToken: userInfo.refreshToken)
+            .sink { [weak self] isSucceed in
+                if isSucceed {
+                    self?.moveToTabBarController()
+                }else {
+                    self?.presentAlertView()
+                }
             }
             .store(in: &cancellables)
+    }
+    
+    private func moveToTabBarController() {
+        let tabBar = KaeraTabbarController()
+        tabBar.modalTransitionStyle = .crossDissolve
+        tabBar.modalPresentationStyle = .fullScreen
+        self.present(tabBar, animated: true)
+    }
+    
+    private func presentAlertView() {
+        let alertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
+        alertVC.setTitleSubTitle(title: "로그인에 실패했습니다 😢", subTitle: "다시 한번 시도해주세요", highlighting: "")
+        self.present(alertVC, animated: true)
     }
     
     private func setLoginButtonAction() {

--- a/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
+++ b/KAERA/KAERA/Scenes/Auth/View/SignInVC.swift
@@ -52,8 +52,9 @@ final class SignInVC: UIViewController {
         let output = signinViewModel.transform(input: SignInViewModel.Input(input))
         output.receive(on: DispatchQueue.main)
             .sink { [weak self] userInfo in
-                //TODO: UserInfo 저장
-                print("유저 정보",userInfo)
+                
+                /// user info 저장
+                KeychainManager.saveUserInfo(id: "\(userInfo.id)", userName: userInfo.name, accessToken: userInfo.accessToken, refreshToken: userInfo.refreshToken)
             }
             .store(in: &cancellables)
     }

--- a/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
+++ b/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
@@ -141,6 +141,12 @@ final class KaeraAlertVC: BaseVC {
     }
     
     func setCancelButtonAction() {
+        if buttonType == .onlyOK {
+            OKButton.press { [weak self] in
+                self?.dismiss(animated: true)
+            }
+        }
+        
         cancelButton.press { [weak self] in
             self?.dismiss(animated: true)
         }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
@@ -36,6 +36,7 @@ final class HomeWorryDetailFooterView: UITableViewHeaderFooterView {
         $0.textColor = .kWhite
         $0.textAlignment = .center
         $0.text = "내가 내린 답은 이거임"
+        $0.numberOfLines = 0
     }
         
     // MARK: - Initialization

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -214,14 +214,15 @@ final class HomeWorryDetailVC: BaseVC {
 
         switch pageType {
         case .digging:
-            if worryDetail.dDay > 0 {
+            /// dDay가 -888인 경우 데드라인 미 지정한 것 
+            if worryDetail.dDay < 800 {
+                dDay = "-∞"
+            }else if worryDetail.dDay > 0 {
                 dDay = "-\(worryDetail.dDay)"
             } else if worryDetail.dDay < 0 {
-                dDay = "+\(worryDetail.dDay)"
+                dDay = "\(worryDetail.dDay)"
             } else if worryDetail.dDay == 0 {
                 dDay = "day"
-            } else {
-                dDay = "-∞"
             }
             navigationBarView.setTitleText(text: "고민캐기 D\(dDay)")
         case .dug:

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -31,6 +31,7 @@ final class HomeWorryDetailVC: BaseVC {
         $0.isScrollEnabled = false
         $0.showsVerticalScrollIndicator = false
         $0.showsHorizontalScrollIndicator = false
+        $0.separatorStyle = .none
     }
     
     private let worryDetailScrollView = UIScrollView().then {


### PR DESCRIPTION
## 💪 작업한 내용
- KeyChainManager 클래스를 이용해 로그인시 캐라서버에서 받은 유저정보를 저장 및 관리 할 수 있도록 했습니다.
  - 키체인 매니저 클래스의 모든 메서드는 class, static 메서드로 인스턴스 생성 없이 KeyChainManager 클래스 타입으로 전역적으로 사용할 수 있도록 했습니다. 
  - 저장하는 정보의 유형을 UserInfoKey라는 enum으로 만들어 그 enum case 의 rawValue인 String을 가지고 키체인에 저장하고, 불러오고, 삭제할때 사용할 수 있는 key 값으로 사용할 수 있도록 했습니다. 
  - save, load, delete시 static 메서드로 구현되어 있는 함수를 이용해 유저 정보 전체를 관리할 수도 있고, 각각의 정보를 UserInforKey 로 직접 관리할 수 있습니다.

### [기타] 수정
- 고민상세 테이블 셀 사이 구분선이 보여서 안보이도록 삭제
- 고민완료 상세 하단 답변 푸터 셀이 콘텐트 내용만큼 안늘어나고 짤려있어 , answerLabel의 line수를 0으로 지정해 여러줄로 늘어나도록함

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 키체인을 처음 다뤄봐서 처음 볼때는 너무 어려워보였는데, 사실 저장하고, 삭제하는 로직이 거의 다 비슷해서 온라인에 정보 짜집기해서 어찌저찌 구현했습니당ㅎㅎ

- 이전 PR에서는 SignInViewModel의 output부분을 output.send를 통해 SignInModel값(유저 정보)을 VC쪽으로 넘겨줬지만 
사실 VC에서 유저 id, name, token 정보를 보여줄 필요는 없기 때문에 VC에 전달하는 output을 통해서는 로그인에 성공 유무를 전달할 수 있도록 output 퍼블리셔 타입을 Bool로 변경 (로그인 실패시 false, 성공시 true 전달 )
- VC에서는 뷰모델의 output을 통해 전달받은 Bool값을 기준으로 로그인 성공시 탭바로 화면전환, 실패시 로그인 실패 알림창을 띄워주도록 하였습니다. 

###  알림창
이번에 로그인 실패 시 알림창을 기존에 캐라 alertVC를 커스텀해서 구현했는데, 사실 iOS에 UIAlertController가 구현되어 있어 이를 이용해서 구현한거랑 비교해서 어떤 알림창이 더 나을지 의견 바랍니다~ (앞으로 네트워크 에러 등 모달 알림창이 필요한 부분에 텍스트만 바꿔서  사용하려고 합니다)


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 캐라 알림창 커스텀 알림뷰 | 아이폰 기본 알림뷰 |
| ---------- | -------- |
| ![IMG_0199](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/844c917b-661f-426b-a60a-28acd8bdac3e) | ![IMG_0198](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/c925d4c5-1ab8-48b1-941c-a5a06584a4a4) |

### 로그인 실패/성공시


https://github.com/TeamHARA/KAERA_iOS/assets/32871014/acf0ac0d-a1a5-484d-ae50-cd997ccb96e8



## 🚨 관련 이슈
- Resolved: #62 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
