### PR TITLE
[Feat] 고민 삭제 API 연결

### DIFF
--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -62,13 +62,13 @@ final class HomeAPI {
     }
     
     // MARK: - DeleteWorry
-    func deleteWorryResponse(param: Int) {
+    func deleteWorryResponse(param: Int, completion: @escaping (EmptyResponse?) -> ()) {
         homeProvider.request(.deleteWorry(worryId: param)) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
-                    self?.deleteWorryResponse = try
-                    result.map(EmptyResponse?.self)
+                    self?.deleteWorryResponse = try result.map(EmptyResponse?.self)
+                    completion(self?.deleteWorryResponse)
                 } catch(let err) {
                     print(err.localizedDescription)
                 }

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -17,6 +17,8 @@ final class HomeAPI {
     
     public private(set) var homeGemListResponse: GeneralArrayResponse<HomeGemListModel>?
     public private(set) var worryDetailResponse: GeneralResponse<WorryDetailModel>?
+    public private(set) var deleteWorryResponse: EmptyResponse?
+    
    
     // MARK: - HomeGemList
     func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
@@ -55,6 +57,23 @@ final class HomeAPI {
             case .failure(let err):
                 print(err.localizedDescription)
                 completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - DeleteWorry
+    func deleteWorryResponse(param: Int) {
+        homeProvider.request(.deleteWorry(worryId: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.deleteWorryResponse = try
+                    result.map(EmptyResponse?.self)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
             }
         }
     }

--- a/KAERA/KAERA/Network/Base/GeneralResponse.swift
+++ b/KAERA/KAERA/Network/Base/GeneralResponse.swift
@@ -52,4 +52,21 @@ struct GeneralArrayResponse<T: Decodable>: Decodable {
 }
 
 /// status, message, success 이외에 정보를 사용하지 않는 경우에 VoidType를 설정해주면 됩니다!
-struct VoidType: Decodable {}
+struct EmptyResponse: Decodable {
+    let status: Int
+    let message: String?
+    let success: Bool?
+    
+    enum CodingKeys: String, CodingKey {
+        case message
+        case status
+        case success
+    }
+    
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        message = (try? values.decode(String.self, forKey: .message)) ?? ""
+        status = (try? values.decode(Int.self, forKey: .status)) ?? 0
+        success = (try? values.decode(Bool.self, forKey: .success)) ?? false
+    }
+}

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -11,6 +11,7 @@ import Moya
 enum HomeService {
     case homeGemList(isSolved: Int)
     case worryDetail(worryId: Int)
+    case deleteWorry(worryId: Int)
 }
 
 extension HomeService: BaseTargetType {
@@ -19,7 +20,7 @@ extension HomeService: BaseTargetType {
         switch self {
         case .homeGemList(let isSolved):
             return APIConstant.worryList + "/\(isSolved)"
-        case .worryDetail(let worryId):
+        case .worryDetail(let worryId), .deleteWorry(let worryId):
             return APIConstant.worry + "/\(worryId)"
         }
     }
@@ -28,19 +29,21 @@ extension HomeService: BaseTargetType {
         switch self {
         case .homeGemList, .worryDetail:
             return .get
+        case .deleteWorry:
+            return .delete
         }
     }
     
     var task: Task {
         switch self {
-        case .homeGemList, .worryDetail:
+        case .homeGemList, .worryDetail, .deleteWorry:
             return .requestPlain
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeGemList, .worryDetail:
+        case .homeGemList, .worryDetail, .deleteWorry:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -250,21 +250,6 @@ final class HomeWorryDetailVC: BaseVC {
         /// -> layoutSubView 메서드가 호출되면서 setDynamicLayout호출
         worryDetailTV.layoutIfNeeded()
     }
-    
-    private func addObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.dismissAlertVCNotification(_:)),
-            name: NSNotification.Name("dismissAlertVC"),
-            object: nil
-        )
-    }
-    
-    @objc func dismissAlertVCNotification(_ notification: Notification) {
-        DispatchQueue.main.async { [self] in
-            self.dismiss(animated: true)
-        }
-    }
 }
 // MARK: - KeyBoard
 extension HomeWorryDetailVC {
@@ -282,7 +267,6 @@ extension HomeWorryDetailVC {
             object: nil)
     }
     
-    
     private func removeKeyboardObserver() {
         NotificationCenter.default.removeObserver(
             self,
@@ -296,6 +280,7 @@ extension HomeWorryDetailVC {
             object: nibName
         )
     }
+    
     @objc
     func keyboardWillAppear(_ notification: NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
@@ -326,7 +311,6 @@ extension HomeWorryDetailVC: UITextViewDelegate {
                 .font: UIFont.kB4R14
             ]
         )
-        
         textView.attributedText = attributedText
     }
     

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -60,6 +60,7 @@ final class HomeWorryDetailVC: BaseVC {
     private var updateDate = ""
     private var worryTitle = ""
     private var templateId = 1
+    private var worryId = 1
     private var dDay = ""
     private var period = ""
     private var pageType: PageType = .digging
@@ -76,6 +77,7 @@ final class HomeWorryDetailVC: BaseVC {
     init(worryId: Int, type: PageType) {
         super.init(nibName: nil, bundle: nil)
         self.pageType = type
+        self.worryId = worryId
         dataBind()
         /// input 전달
         input.send(worryId)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -109,6 +109,19 @@ final class HomeWorryEditVC: BaseVC {
             })
         }
     }
+    
+    private func deleteWorry(completion: @escaping (Bool) -> Void) {
+        /// 고민 삭제 delete 서버 통신
+        HomeAPI.shared.deleteWorryResponse(param: self.worryId) { response in
+            if response?.status == 200 {
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
+    
+    
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -61,7 +61,12 @@ final class HomeWorryEditVC: BaseVC {
         setPressAction()
         hideKeyboardWhenTappedAround()
     }
+    
     // MARK: - Function
+    private func dismissVC() {
+        self.dismiss(animated: true)
+    }
+
     private func setPressAction() {
         editWorryButton.press {
             //TODO: 고민 수정하기 -> 수정용 작성페이지(고민 상세에 있던 데이터 전달)
@@ -86,8 +91,14 @@ final class HomeWorryEditVC: BaseVC {
             let alertVC = KaeraAlertVC(okTitle: "삭제")
             alertVC.setTitleSubTitle(title: "고민을 삭제하시나요?", subTitle: "삭제된 고민은 복구할 수 없어요", highlighting: "삭제")
             alertVC.OKButton.press {
-                //TODO: 삭제 로직 추가
-                print("고민 삭제")
+                /// 고민 삭제 delete 서버 통신 구현
+                HomeAPI.shared.deleteWorryResponse(param: self.worryId)
+                self.dismiss(animated: true, completion: {
+                    /// 현재 뷰에서 present 되있는 뷰를 dismiss 해준다.
+                    self.presentingViewController?.dismiss(animated: true, completion: {
+                        NotificationCenter.default.post(name: NSNotification.Name("dismissAlertVC"), object: nil, userInfo: nil)
+                    })
+                })
             }
             self.present(alertVC, animated: true)
         }
@@ -115,7 +126,6 @@ extension HomeWorryEditVC {
         }
         
         menuStackView.addArrangedSubviews([editWorryButton, editDeadlineButton, deleteWorryButton])
-        
         
         cancelButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -66,7 +66,7 @@ final class HomeWorryEditVC: BaseVC {
     private func dismissVC() {
         self.dismiss(animated: true)
     }
-
+    
     private func setPressAction() {
         editWorryButton.press {
             //TODO: 고민 수정하기 -> 수정용 작성페이지(고민 상세에 있던 데이터 전달)
@@ -87,18 +87,40 @@ final class HomeWorryEditVC: BaseVC {
         }
         
         deleteWorryButton.press {
-            /// 버튼, 타이틀, 서브타이틀, 강조 텍스트, 버튼 액션 추가 가능
+            /// 서버통신 성공 시 띄울 창 구현
             let alertVC = KaeraAlertVC(okTitle: "삭제")
             alertVC.setTitleSubTitle(title: "고민을 삭제하시나요?", subTitle: "삭제된 고민은 복구할 수 없어요", highlighting: "삭제")
-            alertVC.OKButton.press {
-                /// 고민 삭제 delete 서버 통신 구현
-                HomeAPI.shared.deleteWorryResponse(param: self.worryId)
-                self.dismiss(animated: true, completion: {
-                    /// 현재 뷰에서 present 되있는 뷰를 dismiss 해준다.
-                    self.presentingViewController?.dismiss(animated: true, completion: {
-                        NotificationCenter.default.post(name: NSNotification.Name("dismissAlertVC"), object: nil, userInfo: nil)
-                    })
-                })
+            
+            /// 서버통신 실패 시 띄울 알럿 창 구현
+            let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
+            failureAlertVC.setTitleSubTitle(title: "삭제에 실패했어요", subTitle: "다시 한번 시도해주세요.", highlighting: "삭제")
+            
+            alertVC.OKButton.press { [weak self] in
+                /// 서버통신 성공 시 창 모두 dismiss
+                self?.deleteWorry { success in
+                    if success {
+                        self?.dismiss(animated: true) { [weak self] in
+                            if let worryEditVC = self?.presentingViewController,
+                               let worryDetail = worryEditVC.presentingViewController {
+                                worryEditVC.dismiss(animated: true) {
+                                    worryDetail.dismiss(animated: true)
+                                }
+                            }
+                        }
+                    /// 서버통신 실패 시 "삭제 실패" 알럿창 띄우기
+                    } else {
+                        self?.dismiss(animated: true) { [weak self] in
+                            if let worryEditVC = self?.presentingViewController {
+                                worryEditVC.dismiss(animated: true)
+                            }
+                        }
+                        /// "삭제 실패" 알럿창 띄운 뒤 확인 버튼 클릭 시 창 닫히게 구현
+                        self?.present(failureAlertVC, animated: true)
+                        failureAlertVC.OKButton.press {
+                            self?.dismiss(animated: true)
+                        }
+                    }
+                }
             }
             self.present(alertVC, animated: true)
         }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -13,6 +13,8 @@ final class HomeWorryEditVC: BaseVC {
     
     var worryDetail: WorryDetailModel?
     
+    private var worryId: Int = 0
+    
     private let menuStackView = UIStackView().then {
         $0.axis = .vertical
         $0.backgroundColor = .kGray3
@@ -42,6 +44,15 @@ final class HomeWorryEditVC: BaseVC {
         $0.setTitle("취소", for: .normal)
         $0.setTitleColor(UIColor.kRed1, for: .normal)
         $0.layer.cornerRadius = 12
+    }
+    
+    init(worryId: Int) {
+        super.init(nibName: nil, bundle: nil)
+        self.worryId = worryId
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func viewDidLoad() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -142,8 +142,6 @@ final class HomeWorryEditVC: BaseVC {
             }
         }
     }
-    
-    
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteModal/WriteModalVC.swift
@@ -88,7 +88,6 @@ extension WriteModalVC {
         output.receive(on: DispatchQueue.main)
             .sink { [weak self] list in
                 self?.templateList = list
-                print("템플릿 리스트입니다", self?.templateList)
                 self?.templateListCV.reloadData()
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 💪 작업한 내용
- 삭제 버튼 클릭 시 고민을 삭제하는 API를 연결합니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- GeneralResponse 파일에 resposebody가 없는 경우를 대해 EmptyResponse를 추가해주었습니다. 
- self.dismiss(animated: true, completion: {
                    self.presentingViewController?.dismiss(animated: true, completion: {
                        NotificationCenter.default.post(name: NSNotification.Name("dismissAlertVC"), object: nil, userInfo: nil) }) })
<br> AlertVC dismiss 시에 HomeWorryEditVC와 HomeWorryDetailVC를 동시에 dismiss 시켜주기 위해 중첩 completion을 구현해주었습니다. 
- deinit() 에 notificationCenter의 옵저버를 제거해주는 부분을 구현해주었습니다. 



## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
### 고민 삭제 성공 시 화면 ✅
![Simulator Screen Recording - iPhone 13 mini - 2023-10-01 at 20 19 44](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/48a1ddf6-96a6-444c-a1fc-b12aac9532b7)

### 고민 삭제 실패 시 화면 ❌
![Simulator Screen Recording - iPhone 13 mini - 2023-10-09 at 16 45 26](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/6aea4c2f-43f5-4b6e-bf17-22e9b4736665)


<img width="862" alt="스크린샷 2023-10-01 오후 8 19 17" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/b0fc6d7d-11cc-4879-9cfc-6c18e077cf1f">

## 🚨 관련 이슈
- Resolved: #64 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
