### PR TITLE
[Feat] Firebase를 이용한 푸시 알림 구현

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -38,6 +38,34 @@
 		E707646E2ABFF7E800627AA7 /* SignInModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E707646D2ABFF7E800627AA7 /* SignInModel.swift */; };
 		E70764732ABFFF9200627AA7 /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70764722ABFFF9200627AA7 /* SignInViewModel.swift */; };
 		E70764752AC06B6000627AA7 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70764742AC06B6000627AA7 /* KeyChainManager.swift */; };
+		E70764B32AC9972400627AA7 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E70764B22AC9972400627AA7 /* FirebaseAnalytics */; };
+		E70764B52AC9972400627AA7 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = E70764B42AC9972400627AA7 /* FirebaseAnalyticsOnDeviceConversion */; };
+		E70764B72AC9972400627AA7 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E70764B62AC9972400627AA7 /* FirebaseAnalyticsSwift */; };
+		E70764B92AC9972400627AA7 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = E70764B82AC9972400627AA7 /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		E70764BB2AC9972400627AA7 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = E70764BA2AC9972400627AA7 /* FirebaseAppCheck */; };
+		E70764BD2AC9972400627AA7 /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = E70764BC2AC9972400627AA7 /* FirebaseAppDistribution-Beta */; };
+		E70764BF2AC9972400627AA7 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = E70764BE2AC9972400627AA7 /* FirebaseAuth */; };
+		E70764C12AC9972400627AA7 /* FirebaseAuthCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = E70764C02AC9972400627AA7 /* FirebaseAuthCombine-Community */; };
+		E70764C32AC9972400627AA7 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = E70764C22AC9972400627AA7 /* FirebaseCrashlytics */; };
+		E70764C52AC9972400627AA7 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = E70764C42AC9972400627AA7 /* FirebaseDatabase */; };
+		E70764C72AC9972400627AA7 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E70764C62AC9972400627AA7 /* FirebaseDatabaseSwift */; };
+		E70764C92AC9972400627AA7 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = E70764C82AC9972400627AA7 /* FirebaseDynamicLinks */; };
+		E70764CB2AC9972400627AA7 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = E70764CA2AC9972400627AA7 /* FirebaseFirestore */; };
+		E70764CD2AC9972400627AA7 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = E70764CC2AC9972400627AA7 /* FirebaseFirestoreCombine-Community */; };
+		E70764CF2AC9972400627AA7 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E70764CE2AC9972400627AA7 /* FirebaseFirestoreSwift */; };
+		E70764D12AC9972400627AA7 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = E70764D02AC9972400627AA7 /* FirebaseFunctions */; };
+		E70764D32AC9972400627AA7 /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = E70764D22AC9972400627AA7 /* FirebaseFunctionsCombine-Community */; };
+		E70764D52AC9972400627AA7 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = E70764D42AC9972400627AA7 /* FirebaseInAppMessaging-Beta */; };
+		E70764D72AC9972400627AA7 /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = E70764D62AC9972400627AA7 /* FirebaseInAppMessagingSwift-Beta */; };
+		E70764D92AC9972400627AA7 /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = E70764D82AC9972400627AA7 /* FirebaseInstallations */; };
+		E70764DB2AC9972400627AA7 /* FirebaseMLModelDownloader in Frameworks */ = {isa = PBXBuildFile; productRef = E70764DA2AC9972400627AA7 /* FirebaseMLModelDownloader */; };
+		E70764DD2AC9972400627AA7 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = E70764DC2AC9972400627AA7 /* FirebaseMessaging */; };
+		E70764DF2AC9972400627AA7 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = E70764DE2AC9972400627AA7 /* FirebasePerformance */; };
+		E70764E12AC9972400627AA7 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E70764E02AC9972400627AA7 /* FirebaseRemoteConfig */; };
+		E70764E32AC9972400627AA7 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E70764E22AC9972400627AA7 /* FirebaseRemoteConfigSwift */; };
+		E70764E52AC9972400627AA7 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = E70764E42AC9972400627AA7 /* FirebaseStorage */; };
+		E70764E72AC9972400627AA7 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = E70764E62AC9972400627AA7 /* FirebaseStorageCombine-Community */; };
+		E70764EB2AC9980600627AA7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70764EA2AC9980600627AA7 /* GoogleService-Info.plist */; };
 		E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA02A90959A006B2E74 /* HomeService.swift */; };
 		E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA22A909829006B2E74 /* HomeAPI.swift */; };
 		E721EABD2A51D5D900A04AA0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E721EABC2A51D5D900A04AA0 /* Then */; };
@@ -137,6 +165,7 @@
 		E707646D2ABFF7E800627AA7 /* SignInModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInModel.swift; sourceTree = "<group>"; };
 		E70764722ABFFF9200627AA7 /* SignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewModel.swift; sourceTree = "<group>"; };
 		E70764742AC06B6000627AA7 /* KeyChainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainManager.swift; sourceTree = "<group>"; };
+		E70764EA2AC9980600627AA7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		E70C7CA02A90959A006B2E74 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		E70C7CA22A909829006B2E74 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
@@ -208,11 +237,38 @@
 			files = (
 				E7AC12342A51D56F00FE504C /* SnapKit in Frameworks */,
 				E7AC12312A51D54900FE504C /* Moya in Frameworks */,
+				E70764DF2AC9972400627AA7 /* FirebasePerformance in Frameworks */,
+				E70764B32AC9972400627AA7 /* FirebaseAnalytics in Frameworks */,
+				E70764D92AC9972400627AA7 /* FirebaseInstallations in Frameworks */,
+				E70764BD2AC9972400627AA7 /* FirebaseAppDistribution-Beta in Frameworks */,
+				E70764E72AC9972400627AA7 /* FirebaseStorageCombine-Community in Frameworks */,
+				E70764D52AC9972400627AA7 /* FirebaseInAppMessaging-Beta in Frameworks */,
+				E70764C12AC9972400627AA7 /* FirebaseAuthCombine-Community in Frameworks */,
+				E70764E52AC9972400627AA7 /* FirebaseStorage in Frameworks */,
+				E70764CF2AC9972400627AA7 /* FirebaseFirestoreSwift in Frameworks */,
+				E70764E32AC9972400627AA7 /* FirebaseRemoteConfigSwift in Frameworks */,
 				E7AC122F2A51D54900FE504C /* CombineMoya in Frameworks */,
+				E70764D72AC9972400627AA7 /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
+				E70764CD2AC9972400627AA7 /* FirebaseFirestoreCombine-Community in Frameworks */,
+				E70764E12AC9972400627AA7 /* FirebaseRemoteConfig in Frameworks */,
+				E70764BF2AC9972400627AA7 /* FirebaseAuth in Frameworks */,
+				E70764C52AC9972400627AA7 /* FirebaseDatabase in Frameworks */,
+				E70764BB2AC9972400627AA7 /* FirebaseAppCheck in Frameworks */,
+				E70764B92AC9972400627AA7 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+				E70764B72AC9972400627AA7 /* FirebaseAnalyticsSwift in Frameworks */,
+				E70764B52AC9972400627AA7 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
+				E70764C92AC9972400627AA7 /* FirebaseDynamicLinks in Frameworks */,
+				E70764CB2AC9972400627AA7 /* FirebaseFirestore in Frameworks */,
+				E70764C72AC9972400627AA7 /* FirebaseDatabaseSwift in Frameworks */,
+				E70764D12AC9972400627AA7 /* FirebaseFunctions in Frameworks */,
 				E7A94CCB2AA6A46800F231D0 /* KakaoSDKUser in Frameworks */,
 				E721EABD2A51D5D900A04AA0 /* Then in Frameworks */,
+				E70764C32AC9972400627AA7 /* FirebaseCrashlytics in Frameworks */,
 				E7A94CC92AA6A46800F231D0 /* KakaoSDKCommon in Frameworks */,
 				E7A94CC72AA6A46800F231D0 /* KakaoSDKAuth in Frameworks */,
+				E70764DD2AC9972400627AA7 /* FirebaseMessaging in Frameworks */,
+				E70764D32AC9972400627AA7 /* FirebaseFunctionsCombine-Community in Frameworks */,
+				E70764DB2AC9972400627AA7 /* FirebaseMLModelDownloader in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -333,6 +389,7 @@
 			isa = PBXGroup;
 			children = (
 				E7C808F62A4D37FA00F475CE /* Info.plist */,
+				E70764EA2AC9980600627AA7 /* GoogleService-Info.plist */,
 				E7A94CCC2AAC149900F231D0 /* Environment.swift */,
 				E7C808EA2A4D37F800F475CE /* SceneDelegate.swift */,
 				E7C808E82A4D37F800F475CE /* AppDelegate.swift */,
@@ -649,6 +706,33 @@
 				E7A94CC62AA6A46800F231D0 /* KakaoSDKAuth */,
 				E7A94CC82AA6A46800F231D0 /* KakaoSDKCommon */,
 				E7A94CCA2AA6A46800F231D0 /* KakaoSDKUser */,
+				E70764B22AC9972400627AA7 /* FirebaseAnalytics */,
+				E70764B42AC9972400627AA7 /* FirebaseAnalyticsOnDeviceConversion */,
+				E70764B62AC9972400627AA7 /* FirebaseAnalyticsSwift */,
+				E70764B82AC9972400627AA7 /* FirebaseAnalyticsWithoutAdIdSupport */,
+				E70764BA2AC9972400627AA7 /* FirebaseAppCheck */,
+				E70764BC2AC9972400627AA7 /* FirebaseAppDistribution-Beta */,
+				E70764BE2AC9972400627AA7 /* FirebaseAuth */,
+				E70764C02AC9972400627AA7 /* FirebaseAuthCombine-Community */,
+				E70764C22AC9972400627AA7 /* FirebaseCrashlytics */,
+				E70764C42AC9972400627AA7 /* FirebaseDatabase */,
+				E70764C62AC9972400627AA7 /* FirebaseDatabaseSwift */,
+				E70764C82AC9972400627AA7 /* FirebaseDynamicLinks */,
+				E70764CA2AC9972400627AA7 /* FirebaseFirestore */,
+				E70764CC2AC9972400627AA7 /* FirebaseFirestoreCombine-Community */,
+				E70764CE2AC9972400627AA7 /* FirebaseFirestoreSwift */,
+				E70764D02AC9972400627AA7 /* FirebaseFunctions */,
+				E70764D22AC9972400627AA7 /* FirebaseFunctionsCombine-Community */,
+				E70764D42AC9972400627AA7 /* FirebaseInAppMessaging-Beta */,
+				E70764D62AC9972400627AA7 /* FirebaseInAppMessagingSwift-Beta */,
+				E70764D82AC9972400627AA7 /* FirebaseInstallations */,
+				E70764DA2AC9972400627AA7 /* FirebaseMLModelDownloader */,
+				E70764DC2AC9972400627AA7 /* FirebaseMessaging */,
+				E70764DE2AC9972400627AA7 /* FirebasePerformance */,
+				E70764E02AC9972400627AA7 /* FirebaseRemoteConfig */,
+				E70764E22AC9972400627AA7 /* FirebaseRemoteConfigSwift */,
+				E70764E42AC9972400627AA7 /* FirebaseStorage */,
+				E70764E62AC9972400627AA7 /* FirebaseStorageCombine-Community */,
 			);
 			productName = KAERA;
 			productReference = E7C808E52A4D37F800F475CE /* KAERA.app */;
@@ -683,6 +767,7 @@
 				E7AC12322A51D56F00FE504C /* XCRemoteSwiftPackageReference "SnapKit" */,
 				E721EABB2A51D5D900A04AA0 /* XCRemoteSwiftPackageReference "Then" */,
 				E7A94CC52AA6A46800F231D0 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = E7C808E62A4D37F800F475CE /* Products */;
 			projectDirPath = "";
@@ -704,6 +789,7 @@
 				E7C30F622A533D08002BD782 /* NanumSquareNeoTTF-bRg.ttf in Resources */,
 				E7C30F632A533D08002BD782 /* NanumSquareNeoTTF-cBd.ttf in Resources */,
 				E79AAC5A2A531E3300F3F439 /* NanumMyeongjoOTF.otf in Resources */,
+				E70764EB2AC9980600627AA7 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1015,6 +1101,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.15.0;
+			};
+		};
 		E721EABB2A51D5D900A04AA0 /* XCRemoteSwiftPackageReference "Then" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/devxoul/Then";
@@ -1050,6 +1144,141 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E70764B22AC9972400627AA7 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		E70764B42AC9972400627AA7 /* FirebaseAnalyticsOnDeviceConversion */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsOnDeviceConversion;
+		};
+		E70764B62AC9972400627AA7 /* FirebaseAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsSwift;
+		};
+		E70764B82AC9972400627AA7 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		E70764BA2AC9972400627AA7 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
+		};
+		E70764BC2AC9972400627AA7 /* FirebaseAppDistribution-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAppDistribution-Beta";
+		};
+		E70764BE2AC9972400627AA7 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		E70764C02AC9972400627AA7 /* FirebaseAuthCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAuthCombine-Community";
+		};
+		E70764C22AC9972400627AA7 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		E70764C42AC9972400627AA7 /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabase;
+		};
+		E70764C62AC9972400627AA7 /* FirebaseDatabaseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabaseSwift;
+		};
+		E70764C82AC9972400627AA7 /* FirebaseDynamicLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDynamicLinks;
+		};
+		E70764CA2AC9972400627AA7 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		E70764CC2AC9972400627AA7 /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		E70764CE2AC9972400627AA7 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
+		};
+		E70764D02AC9972400627AA7 /* FirebaseFunctions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFunctions;
+		};
+		E70764D22AC9972400627AA7 /* FirebaseFunctionsCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFunctionsCombine-Community";
+		};
+		E70764D42AC9972400627AA7 /* FirebaseInAppMessaging-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessaging-Beta";
+		};
+		E70764D62AC9972400627AA7 /* FirebaseInAppMessagingSwift-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessagingSwift-Beta";
+		};
+		E70764D82AC9972400627AA7 /* FirebaseInstallations */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseInstallations;
+		};
+		E70764DA2AC9972400627AA7 /* FirebaseMLModelDownloader */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMLModelDownloader;
+		};
+		E70764DC2AC9972400627AA7 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		E70764DE2AC9972400627AA7 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
+		E70764E02AC9972400627AA7 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
+		E70764E22AC9972400627AA7 /* FirebaseRemoteConfigSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfigSwift;
+		};
+		E70764E42AC9972400627AA7 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		E70764E62AC9972400627AA7 /* FirebaseStorageCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E70764B12AC9972400627AA7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseStorageCombine-Community";
+		};
 		E721EABC2A51D5D900A04AA0 /* Then */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E721EABB2A51D5D900A04AA0 /* XCRemoteSwiftPackageReference "Then" */;

--- a/KAERA/KAERA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KAERA/KAERA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,84 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
+      }
+    },
+    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
         "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
         "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "8a8ec57a272e0d31480fb0893dda0cf4f769b57e",
+        "version" : "10.15.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "03b9beee1a61f62d32c521e172e192a1663a5e8b",
+        "version" : "10.13.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "aae45a320fd0d11811820335b1eabc8753902a40",
+        "version" : "9.2.5"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "c38ce365d77b04a9a300c31061c5227589e5597b",
+        "version" : "7.11.5"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f1b366129d1125be7db83247e003fc333104b569",
+        "version" : "1.50.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d415594121c9e8a4f9d79cecee0965cf35e74dbd",
+        "version" : "3.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {
@@ -19,12 +91,39 @@
       }
     },
     {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
       "identity" : "moya",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Moya/Moya",
       "state" : {
         "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
         "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -52,6 +151,15 @@
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "3c54ab05249f59f2c6641dd2920b8358ea9ed127",
+        "version" : "1.24.0"
       }
     },
     {

--- a/KAERA/KAERA/Application/AppDelegate.swift
+++ b/KAERA/KAERA/Application/AppDelegate.swift
@@ -7,30 +7,143 @@
 
 import UIKit
 import KakaoSDKCommon
+import Firebase
+import UserNotifications
+
+
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
+        
         KakaoSDK.initSDK(appKey: Environment.kakaoAppKey)
+        // Firebase SDK 초기화
+        FirebaseApp.configure()
+        
+        // 원격 알림 등록
+        UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
+        
+        /// 메시지 대리자 설정
+        Messaging.messaging().delegate = self
+        
+        /// 푸시 권한 요청하기
+        requestNotificationPermission()
+        
+        /// 자동 초기화 방지
+        Messaging.messaging().isAutoInitEnabled = true
+        
+        /// 현재 등록 토큰 가져오기
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("Error fetching FCM registration token: \(error)")
+            } else if let token = token {
+                print("FCM registration token: \(token)")
+                /// 키체인에 FCM Token 저장
+                KeychainManager.save(key: .fcmToken, value: token)
+            }
+        }
+        
         return true
     }
-
+    
+    /// 푸시 권한 요청
+    private func requestNotificationPermission() {
+        var originalStatus: Bool = false
+        /// 현재 알림 세팅 값 확인
+        UNUserNotificationCenter.current().getNotificationSettings { setting in
+            originalStatus = setting.alertSetting == .enabled
+        }
+        /// 요청할 권한 옵션
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: {didAllow, Error in
+            if didAllow {
+                if originalStatus == false {
+                    debugPrint("Push: 권한 허용")
+                }
+            } else {
+                debugPrint("Push: 권한 거부")
+            }
+        })
+    }
+    
     // MARK: UISceneSession Lifecycle
-
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    /// APN 토큰과 등록 토큰 매핑
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+    
+    /// APN 토큰과 등록 토큰 매핑 실패
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        debugPrint("APN 토큰 등록 실패", "fail")
+    }
+    
+    /// 디바이스 세로방향으로 고정
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
 }
 
+// MARK: - MessagingDelegate
+extension AppDelegate: MessagingDelegate {
+    
+    /// 토큰 갱신 모니터링 메서드
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        print("Firebase registration token: \(String(describing: fcmToken))")
+        
+        if let fcmToken {
+            print("Saved FCM Token: \(fcmToken)")
+            /// 키체인에 FCM Token 저장
+            KeychainManager.save(key: .fcmToken, value: fcmToken)
+        }else {
+            print("Failed Saving FCM Token")
+        }
+        
+        /// 토큰을 NotificaitonCenter로 post
+        let dataDict: [String: String] = ["token": fcmToken ?? ""]
+        NotificationCenter.default.post(
+            name: Notification.Name("FCMToken"),
+            object: nil,
+            userInfo: dataDict
+        )
+       
+    }
+    
+    /// 아래 코드로 갱신된 토큰을 옵저버로 받아서 사용가능
+    /*
+    NotificationCenter.default.addObserver(self, selector: #selector(getNotification), name: Notification.Name(rawValue: "FCMToken"), object: nil)
+    
+    @objc func getNotification(_ notification: NSNotification){
+        guard let tokenDictionary = notification.userInfo as! [String:Any]? else {
+            return
+        }
+        let token: String  = tokenDictionary["token"] as! String
+        print("Got TOKEN \(token)")
+    }
+     */
+    
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    
+    /// foreGround에 푸시알림이 올 때 실행되는 메서드 + completion으로 어떻게 알림을 보여줄지 선택가능
+    func userNotificationCenter(_ center: UNUserNotificationCenter,willPresent notification: UNNotification,withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.badge, .sound, .list, .banner])
+    }
+    
+    /// 푸시알림을 클릭했을 때 실행되는 메서드
+    func userNotificationCenter(_ center: UNUserNotificationCenter,didReceive response: UNNotificationResponse,withCompletionHandler completionHandler: @escaping () -> Void) {
+        //TODO: 푸시알림을 통해 진입시 액션 구현
+        completionHandler()
+    }
+}

--- a/KAERA/KAERA/Application/GoogleService-Info.plist
+++ b/KAERA/KAERA/Application/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyBn6DC6aRipSYoCxBwYdxdT4r2Jv2yzepY</string>
+	<key>GCM_SENDER_ID</key>
+	<string>61612522426</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.hara.kaera</string>
+	<key>PROJECT_ID</key>
+	<string>kaera-8d636</string>
+	<key>STORAGE_BUCKET</key>
+	<string>kaera-8d636.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:61612522426:ios:8384d4658f189580cabb83</string>
+</dict>
+</plist>

--- a/KAERA/KAERA/Application/Info.plist
+++ b/KAERA/KAERA/Application/Info.plist
@@ -50,5 +50,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/KAERA/KAERA/Application/KeyChainManager.swift
+++ b/KAERA/KAERA/Application/KeyChainManager.swift
@@ -12,6 +12,7 @@ enum UserInfoKey: String {
     case userName
     case acessToken
     case refreshToken
+    case fcmToken
 }
 
 struct UserInfoModel {
@@ -19,6 +20,7 @@ struct UserInfoModel {
     let userName: String?
     let accessToken: String?
     let refreshToken: String?
+    let fcmToken: String?
 }
 
 final class KeychainManager {
@@ -98,11 +100,12 @@ final class KeychainManager {
     }
     
     // 사용자 정보 및 토큰 저장
-    static func saveUserInfo(id: String, userName: String, accessToken: String, refreshToken: String) {
+    static func saveUserInfo(id: String = "", userName: String = "", accessToken: String = "", refreshToken: String = "", fcmToken: String = "") {
         KeychainManager.save(key: .userId, value: id)
         KeychainManager.save(key: .userName, value: userName)
         KeychainManager.save(key: .acessToken, value: accessToken)
         KeychainManager.save(key: .refreshToken, value: refreshToken)
+        KeychainManager.save(key: .fcmToken, value: fcmToken)
     }
     
     // 사용자 정보 및 토큰 로드
@@ -111,8 +114,9 @@ final class KeychainManager {
         let userName = KeychainManager.load(key: .userName)
         let accessToken = KeychainManager.load(key: .acessToken)
         let refreshToken = KeychainManager.load(key: .refreshToken)
+        let fcmToken = KeychainManager.load(key: .fcmToken)
         
-        return UserInfoModel(userId: userId, userName: userName, accessToken: accessToken, refreshToken: refreshToken)
+        return UserInfoModel(userId: userId, userName: userName, accessToken: accessToken, refreshToken: refreshToken, fcmToken: fcmToken)
     }
     
     static func clearAllUserInfo() {
@@ -120,6 +124,7 @@ final class KeychainManager {
         KeychainManager.delete(key: .userName)
         KeychainManager.delete(key: .acessToken)
         KeychainManager.delete(key: .refreshToken)
+        KeychainManager.delete(key: .fcmToken)
     }
     
 }

--- a/KAERA/KAERA/KAERA.entitlements
+++ b/KAERA/KAERA/KAERA.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -87,7 +87,7 @@ extension SignInViewModel {
     }
     
     private func postAppleLogin(token: String) {
-        print(token)
+        print("아이덴티티토큰", token)
     }
 }
 
@@ -108,6 +108,11 @@ extension SignInViewModel: ASAuthorizationControllerDelegate {
             if let identityToken = appleIDCredential.identityToken,
                let tokenString = String(data: identityToken, encoding: .utf8) {
                 postAppleLogin(token: tokenString)
+            }
+            
+            if let authorizationCode = appleIDCredential.authorizationCode {
+                let authorizationCodeString = String(data: authorizationCode, encoding: .utf8)
+                print("인가코드", authorizationCodeString)
             }
            
         default:


### PR DESCRIPTION
## 💪 작업한 내용
- Firebase를 이용해 푸시 알림을 구현했습니다.
  -  Apple Developer에서 Key를 발급 받아서 저장하고
  - 기존에 초대가 되어있는 Firebase내 캐라 프로젝트로 가서 iOS 프로젝트를 추가했습니다.
   - 이때 입력하는 BundleID는 Apple에 등록된 BundleID와 같은 값을 입력하고
   - Google Infoplist를 xcode 파일에 추가, Firebase SDK를 캐라 프로젝트에 추가 등 Firebase 페이지에서 안내하는 순서대로 진행했습니다.
   
  - 이후 클라우드 메시징 탭으로 들어가 위에 발급 받은 키를 등록했습니다.
  - xcode에서 capability 중 pushNotification, BackGround Modes(Remote notifiction 체크)를 추가하였고
  - AppDelegate에서 Firebase Notification 관련 메서드들을 설정하였습니다.


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- [블로그](https://dokit.tistory.com/49)와 Firebase에 설정 관련내용이 잘 되어있어 거의 보면서 따라하는 식으로 잘 구현했고, AppDelegate 메서드 설정은 푸시알림을 구현했던 다른 프로젝트 코드를 대부분 참고해 구현했습니다.
- 아직 푸시알림 클릭시 어떻게 동작을 시켜야할지 부분이 정해지지 않이 추후 해당 부분을 추가로 구현해야 할 것입니다.
- 또한 기존 프로젝트에서는 Splach 부분에서 푸시알림 권한을 요청하지만 현재는 appDelegate에서만 구현되어있어 해당부분 수정 예상됩니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
- 푸시알림 테스트
![IMG_5FE0396DB0A3-1](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/101f2913-fbb1-4133-9388-8eb1822d262d)


## 🚨 관련 이슈
- Resolved: #67


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
