### PR TITLE
[Feat] 데드라인 수정 API 연결

### DIFF
--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -18,10 +18,10 @@ final class HomeAPI {
     public private(set) var homeGemListResponse: GeneralArrayResponse<HomeGemListModel>?
     public private(set) var worryDetailResponse: GeneralResponse<WorryDetailModel>?
     public private(set) var deleteWorryResponse: EmptyResponse?
-    
+    public private(set) var updateDeadlineResponse: GeneralResponse<String>?
    
     // MARK: - HomeGemList
-    func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> () ) {
+    func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> ()) {
         homeProvider.request(.homeGemList(isSolved: param)) { [weak self] response in
             switch response {
             case .success(let result):
@@ -62,7 +62,7 @@ final class HomeAPI {
     }
     
     // MARK: - DeleteWorry
-    func deleteWorryResponse(param: Int, completion: @escaping (EmptyResponse?) -> ()) {
+    func deleteWorry(param: Int, completion: @escaping (EmptyResponse?) -> ()) {
         homeProvider.request(.deleteWorry(worryId: param)) { [weak self] response in
             switch response {
             case .success(let result):
@@ -74,6 +74,26 @@ final class HomeAPI {
                 }
             case .failure(let err):
                 print(err.localizedDescription)
+            }
+        }
+    }
+    
+    // MARK: - UpdateDeadline
+    func updateDeadline(param: PatchDeadlineModel, completion: @escaping (GeneralResponse<String>?) -> ()) {
+        homeProvider.request(.updateDeadline(param: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.updateDeadlineResponse = try result.map(GeneralResponse<String>?.self)
+                    guard let worryDeadline = self?.updateDeadlineResponse else { return }
+                    completion(worryDeadline)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
             }
         }
     }

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -12,6 +12,7 @@ enum HomeService {
     case homeGemList(isSolved: Int)
     case worryDetail(worryId: Int)
     case deleteWorry(worryId: Int)
+    case updateDeadline(param: PatchDeadlineModel)
 }
 
 extension HomeService: BaseTargetType {
@@ -22,6 +23,8 @@ extension HomeService: BaseTargetType {
             return APIConstant.worryList + "/\(isSolved)"
         case .worryDetail(let worryId), .deleteWorry(let worryId):
             return APIConstant.worry + "/\(worryId)"
+        case .updateDeadline:
+            return APIConstant.worry + "/deadline"
         }
     }
     
@@ -31,6 +34,8 @@ extension HomeService: BaseTargetType {
             return .get
         case .deleteWorry:
             return .delete
+        case .updateDeadline:
+            return .patch
         }
     }
     
@@ -38,12 +43,14 @@ extension HomeService: BaseTargetType {
         switch self {
         case .homeGemList, .worryDetail, .deleteWorry:
             return .requestPlain
+        case .updateDeadline(let param):
+            return .requestJSONEncodable(param)
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeGemList, .worryDetail, .deleteWorry:
+        case .homeGemList, .worryDetail, .deleteWorry, .updateDeadline:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
@@ -23,9 +23,12 @@ struct WorryDetailModel: Codable {
     }
 }
 
-
-
 // MARK: - Review
 struct Review: Codable {
     let content, updatedAt: String
+}
+
+struct PatchDeadlineModel: Codable {
+    var worryId: Int
+    var dayCount: Int
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeVC.swift
@@ -40,7 +40,7 @@ final class HomeVC: BaseVC {
     private let pageVC = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     private let homeDiggingVC = HomeGemStoneVC(type: .digging)
     private let homeDugVC = HomeGemStoneVC(type: .dug)
-    private lazy var contents: [UIViewController] = [ homeDiggingVC, homeDugVC ]
+    private lazy var contents: [UIViewController] = [homeDiggingVC, homeDugVC ]
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -109,6 +109,7 @@ final class HomeWorryDetailVC: BaseVC {
         setReviewTextView()
         hideKeyboardWhenTappedAround()
         setPressAction()
+        addObserver()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -221,8 +222,8 @@ final class HomeWorryDetailVC: BaseVC {
         
         switch pageType {
         case .digging:
-            /// dDay가 -888인 경우 데드라인 미 지정한 것 
-            if worryDetail.dDay < 800 {
+            /// dDay가 -888인 경우 데드라인 미 지정한 것
+            if worryDetail.dDay < -800 {
                 dDay = "-∞"
             }else if worryDetail.dDay > 0 {
                 dDay = "-\(worryDetail.dDay)"
@@ -250,6 +251,18 @@ final class HomeWorryDetailVC: BaseVC {
         /// layout을 업데이트 시키면서 worryDetailTV의 콘텐트 사이즈 값이 실제 크기에 맞게 조정
         /// -> layoutSubView 메서드가 호출되면서 setDynamicLayout호출
         worryDetailTV.layoutIfNeeded()
+    }
+    
+    /// 데드라인 수정시 받는 notification을 관리하는 observer 추가
+    func addObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleDeadlineUpdate(_:)), name: NSNotification.Name("updateDeadline"), object: nil)
+    }
+    
+    /// 전달 받은 수정된 데드라인 일자로 navigationBar Title 변경
+    @objc func handleDeadlineUpdate(_ notification: Notification) {
+        if let userInfo = notification.userInfo, let deadline = userInfo["deadline"] as? Int {
+            navigationBarView.setTitleText(text: "고민캐기 D-\(deadline)")
+        }
     }
 }
 // MARK: - KeyBoard
@@ -440,3 +453,4 @@ extension HomeWorryDetailVC {
         }
     }
 }
+

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -81,7 +81,6 @@ final class HomeWorryEditVC: BaseVC {
         editDeadlineButton.press {
             let pickerVC = WritePickerVC(type: .patch)
             pickerVC.worryId = self.worryId
-            print("worryId 보낼거 ", self.worryId, type(of: self.worryId))
             pickerVC.modalPresentationStyle = .fullScreen
             pickerVC.modalTransitionStyle = .coverVertical
             pickerVC.completeWritingBtn.press {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -60,6 +60,7 @@ final class HomeWorryEditVC: BaseVC {
         setUI()
         setPressAction()
         hideKeyboardWhenTappedAround()
+        addObserver()
     }
     
     // MARK: - Function
@@ -79,11 +80,17 @@ final class HomeWorryEditVC: BaseVC {
         
         editDeadlineButton.press {
             //TODO: 데드라인 수정하기 -> 기존 데드라인 표시
-            let pickerVC = WritePickerVC()
             print("디데이", self.worryDetail?.dDay)
+            let pickerVC = WritePickerVC(type: .patch)
+            pickerVC.worryId = self.worryId
+            print("worryId 보낼거 ", self.worryId, type(of: self.worryId))
             pickerVC.modalPresentationStyle = .fullScreen
             pickerVC.modalTransitionStyle = .coverVertical
+            pickerVC.completeWritingBtn.press {
+                self.dismiss(animated: true)
+            }
             self.present(pickerVC, animated: true)
+            pickerVC.datePickerView.selectRow(abs(self.worryDetail?.dDay ?? 0) - 1, inComponent: 0, animated: true)
         }
         
         deleteWorryButton.press {
@@ -134,12 +141,27 @@ final class HomeWorryEditVC: BaseVC {
     
     private func deleteWorry(completion: @escaping (Bool) -> Void) {
         /// 고민 삭제 delete 서버 통신
-        HomeAPI.shared.deleteWorryResponse(param: self.worryId) { response in
+        HomeAPI.shared.deleteWorry(param: self.worryId) { response in
             if response?.status == 200 {
                 completion(true)
             } else {
                 completion(false)
             }
+        }
+    }
+    
+    private func addObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.didCompleteWritingNotification(_:)),
+            name: NSNotification.Name("CompleteWriting"),
+            object: nil
+        )
+    }
+    
+    @objc func didCompleteWritingNotification(_ notification: Notification) {
+        DispatchQueue.main.async { [self] in
+            self.dismiss(animated: true)
         }
     }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -157,7 +157,7 @@ final class HomeWorryEditVC: BaseVC {
     }
     
     @objc func didCompleteWritingNotification(_ notification: Notification) {
-        DispatchQueue.main.async { [self] in
+        DispatchQueue.main.async {
             self.dismiss(animated: true)
         }
     }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -75,12 +75,10 @@ final class HomeWorryEditVC: BaseVC {
             print("고민상세", self.worryDetail)
             writeVC.modalPresentationStyle = .fullScreen
             writeVC.modalTransitionStyle = .coverVertical
-            self.present(writeVC,animated: true)
+            self.present(writeVC, animated: true)
         }
         
         editDeadlineButton.press {
-            //TODO: 데드라인 수정하기 -> 기존 데드라인 표시
-            print("디데이", self.worryDetail?.dDay)
             let pickerVC = WritePickerVC(type: .patch)
             pickerVC.worryId = self.worryId
             print("worryId 보낼거 ", self.worryId, type(of: self.worryId))

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -124,10 +124,20 @@ class WritePickerVC: UIViewController {
             case .patch:
                 deadlineContent.worryId = self.worryId
                 deadlineContent.dayCount = contentInfo.deadline
-                self.patchWorryDeadline()
-                NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": contentInfo.deadline])
+                /// 서버통신 실패 시 띄울 알럿 창 구현
+                let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
+                failureAlertVC.setTitleSubTitle(title: "일자 수정에 실패했어요", subTitle: "다시 한번 시도해주세요.", highlighting: "실패")
+                self.patchWorryDeadline { success in
+                    if success {
+                        NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": self.contentInfo.deadline])
+                    } else {
+                        self.present(failureAlertVC, animated: true)
+                        failureAlertVC.OKButton.press {
+                            self.dismiss(animated: true)
+                        }
+                    }
+                }
             }
-            
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
                 view.layoutIfNeeded()
@@ -151,10 +161,14 @@ class WritePickerVC: UIViewController {
         }
     }
     
-    func patchWorryDeadline() {
+    func patchWorryDeadline(completion: @escaping (Bool) -> Void) {
         /// 서버로 고민 내용을 POST 시켜줌
-        HomeAPI.shared.updateDeadline(param: deadlineContent){ result in
-            guard let result = result, let _ = result.data else { return }
+        HomeAPI.shared.updateDeadline(param: deadlineContent) { response in
+            if response?.status == 200 {
+                completion(true)
+            } else {
+                completion(false)
+            }
         }
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -9,6 +9,11 @@ import UIKit
 import SnapKit
 import Then
 
+enum DeadlineType {
+    case post
+    case patch
+}
+
 class WritePickerVC: UIViewController {
     
     // MARK: - Properties
@@ -20,6 +25,10 @@ class WritePickerVC: UIViewController {
     
     let contentInfo = ContentInfo.shared
     var publishedContent = WorryContentRequestModel(templateId: 1, title: "", answers: [], deadline: -1)
+    
+    var worryId: Int = 0
+    
+    var deadlineContent = PatchDeadlineModel(worryId: 1, dayCount: 1)
     
     private let pickerViewTitle = UILabel().then {
         $0.text = "이 고민, 언제까지 끝낼까요?"
@@ -51,7 +60,7 @@ class WritePickerVC: UIViewController {
         $0.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
     }
     
-    private let completeWritingBtn = UIButton().then {
+    let completeWritingBtn = UIButton().then {
         $0.backgroundColor = .kGray5
         $0.titleLabel?.font = .kB2R16
         $0.setTitle("작성완료", for: .normal)
@@ -75,6 +84,17 @@ class WritePickerVC: UIViewController {
         $0.setAttributedTitle(attributedTitle, for: .normal)
     }
     
+    private var deadlineType: DeadlineType = .post
+    
+    // MARK: - Initialization
+    init(type: DeadlineType) {
+        super.init(nibName: nil, bundle: nil)
+        self.deadlineType = type
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Life Cycles
     override func viewDidLoad() {
@@ -86,7 +106,6 @@ class WritePickerVC: UIViewController {
     
     // MARK: - Functions
     private func pressBtn() {
-        
         completeWritingBtn.press { [self] in
             /// picker에서 고른 숫자를 deadline으로 설정해줌.
             let selectedRow = datePickerView.selectedRow(inComponent: 0)
@@ -99,7 +118,15 @@ class WritePickerVC: UIViewController {
             publishedContent.answers = contentInfo.answers
             publishedContent.deadline = contentInfo.deadline
             
-            self.postWorryContent()
+            switch self .deadlineType {
+            case .post:
+                self.postWorryContent()
+            case .patch:
+                deadlineContent.worryId = self.worryId
+                deadlineContent.dayCount = contentInfo.deadline
+                self.patchWorryDeadline()
+                NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": contentInfo.deadline])
+            }
             
             UIView.animate(withDuration: 0.5, animations: { [self] in
                 view.alpha = 0
@@ -120,6 +147,13 @@ class WritePickerVC: UIViewController {
     private func postWorryContent() {
         /// 서버로 고민 내용을 POST 시켜줌
         WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+            guard let result = result, let _ = result.data else { return }
+        }
+    }
+    
+    func patchWorryDeadline() {
+        /// 서버로 고민 내용을 POST 시켜줌
+        HomeAPI.shared.updateDeadline(param: deadlineContent){ result in
             guard let result = result, let _ = result.data else { return }
         }
     }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -93,7 +93,7 @@ class WriteVC: BaseVC {
     /// tableView의 데이터들을 담는 싱글톤 클래스
     let contentInfo = ContentInfo.shared
     
-    private let pickerVC = WritePickerVC()
+    private let pickerVC = WritePickerVC(type: .post)
     
     // MARK: - Life Cycles
     override func viewDidLoad() {


### PR DESCRIPTION
## 💪 작업한 내용
- 고민상세보기뷰에서 데드라인을 수정하는 API를 연결합니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- pickerVC가 intialize 될 때 case를 post, patch 2종류로 나누어 데드라인 수정 시에는 patch case로 initialize되게끔 해주었습니다. 
- '데드라인 수정하기' 버튼 클릭 시에 원래 데드라인이 pickerView에서 선택된 상태로 있게끔 구현하였습니다. 
- 데드라인 수정 완료 시에 선택된 데드라인을 WriteDetailVC가 notificationCenter를 통해 전달받을 수 있게끔 하였습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-10-15 at 01 30 32](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/9c16036f-f5b9-4718-9a92-882da6616131)


## 🚨 관련 이슈
- Resolved: #69 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
