### PR TITLE
[Feat] 고민수정 API 연결

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		850C55962ADB2AA00088ABBB /* WorryPatchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850C55952ADB2AA00088ABBB /* WorryPatchManager.swift */; };
 		85887D822A5C429F00F7FB21 /* WriteModalVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85887D812A5C429F00F7FB21 /* WriteModalVC.swift */; };
 		85887D842A5C42A700F7FB21 /* WriteModalCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85887D832A5C42A700F7FB21 /* WriteModalCVC.swift */; };
 		85887D8C2A5D084800F7FB21 /* TemplateListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85887D8B2A5D084800F7FB21 /* TemplateListModel.swift */; };
@@ -24,7 +25,7 @@
 		85A8492F2A87A9EC009F1468 /* TemplateContentTV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */; };
 		85A849312A87A9F7009F1468 /* TemplateContentTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */; };
 		85A849332A87DA36009F1468 /* TemplateContentHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */; };
-		85E349492AC06C63007D9956 /* ContentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E349482AC06C63007D9956 /* ContentInfo.swift */; };
+		85E349492AC06C63007D9956 /* WorryPostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E349482AC06C63007D9956 /* WorryPostManager.swift */; };
 		85EBC7F12A5AD7BC00B9E891 /* KaeraTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F02A5AD7BC00B9E891 /* KaeraTabbarController.swift */; };
 		85EBC7F32A5AD93200B9E891 /* HomeGemStoneVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */; };
 		85EBC7F52A5AD94100B9E891 /* WriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EBC7F42A5AD94100B9E891 /* WriteVC.swift */; };
@@ -135,6 +136,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		850C55952ADB2AA00088ABBB /* WorryPatchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryPatchManager.swift; sourceTree = "<group>"; };
 		85887D812A5C429F00F7FB21 /* WriteModalVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteModalVC.swift; sourceTree = "<group>"; };
 		85887D832A5C42A700F7FB21 /* WriteModalCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteModalCVC.swift; sourceTree = "<group>"; };
 		85887D8B2A5D084800F7FB21 /* TemplateListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListModel.swift; sourceTree = "<group>"; };
@@ -152,7 +154,7 @@
 		85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentTV.swift; sourceTree = "<group>"; };
 		85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentTVC.swift; sourceTree = "<group>"; };
 		85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContentHeaderView.swift; sourceTree = "<group>"; };
-		85E349482AC06C63007D9956 /* ContentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentInfo.swift; sourceTree = "<group>"; };
+		85E349482AC06C63007D9956 /* WorryPostManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryPostManager.swift; sourceTree = "<group>"; };
 		85EBC7F02A5AD7BC00B9E891 /* KaeraTabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KaeraTabbarController.swift; sourceTree = "<group>"; };
 		85EBC7F22A5AD93200B9E891 /* HomeGemStoneVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemStoneVC.swift; sourceTree = "<group>"; };
 		85EBC7F42A5AD94100B9E891 /* WriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteVC.swift; sourceTree = "<group>"; };
@@ -657,7 +659,8 @@
 		E7BB4F4C2A5EF7520018312B /* View */ = {
 			isa = PBXGroup;
 			children = (
-				85E349482AC06C63007D9956 /* ContentInfo.swift */,
+				850C55952ADB2AA00088ABBB /* WorryPatchManager.swift */,
+				85E349482AC06C63007D9956 /* WorryPostManager.swift */,
 				85A849322A87DA36009F1468 /* TemplateContentHeaderView.swift */,
 				85A849302A87A9F7009F1468 /* TemplateContentTVC.swift */,
 				85A8492E2A87A9EC009F1468 /* TemplateContentTV.swift */,
@@ -836,6 +839,7 @@
 				E79AAC212A52F19300F3F439 /* ToastMessageColorType.swift in Sources */,
 				E73CA3E72A6B5D2500BAC9D6 /* HomeWorryDetailHeaderView.swift in Sources */,
 				E7AC12232A51D08300FE504C /* Temp_DataModel.swift in Sources */,
+				850C55962ADB2AA00088ABBB /* WorryPatchManager.swift in Sources */,
 				85887DA02A612E1000F7FB21 /* TemplateInfoTVC.swift in Sources */,
 				E7BB4F3B2A5ED3610018312B /* HomeVC.swift in Sources */,
 				E79AAC342A52F2C300F3F439 /* UIViewController+.swift in Sources */,
@@ -908,7 +912,7 @@
 				E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */,
 				E79AAC352A52F2C300F3F439 /* UIImageView+.swift in Sources */,
 				85887D9C2A605D0B00F7FB21 /* TemplateInfoVC.swift in Sources */,
-				85E349492AC06C63007D9956 /* ContentInfo.swift in Sources */,
+				85E349492AC06C63007D9956 /* WorryPostManager.swift in Sources */,
 				E7BB4F4F2A5EF81C0018312B /* WorryListViewModel.swift in Sources */,
 				E7FEC09E2A6F6C76006F36BF /* ViewModelType.swift in Sources */,
 			);

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -19,6 +19,7 @@ final class HomeAPI {
     public private(set) var worryDetailResponse: GeneralResponse<WorryDetailModel>?
     public private(set) var deleteWorryResponse: EmptyResponse?
     public private(set) var updateDeadlineResponse: GeneralResponse<String>?
+    public private(set) var editWorryResponse: GeneralResponse<String>?
    
     // MARK: - HomeGemList
     func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> ()) {
@@ -87,6 +88,26 @@ final class HomeAPI {
                     self?.updateDeadlineResponse = try result.map(GeneralResponse<String>?.self)
                     guard let worryDeadline = self?.updateDeadlineResponse else { return }
                     completion(worryDeadline)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - EditWorry
+    func editWorry(param: PatchWorryModel, completion: @escaping (GeneralResponse<String>?) -> ()) {
+        homeProvider.request(.editWorry(param: param)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.editWorryResponse = try result.map(GeneralResponse<String>?.self)
+                    guard let worryContent = self?.editWorryResponse else { return }
+                    completion(worryContent)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -15,7 +15,7 @@ final class WriteAPI {
     private let writeProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
     
     // tableView의 데이터들을 담는 싱글톤 클래스
-    let contentInfo = ContentInfo.shared
+    let contentInfo = WorryPostManager.shared
     
     private init() { }
     

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -13,6 +13,7 @@ enum HomeService {
     case worryDetail(worryId: Int)
     case deleteWorry(worryId: Int)
     case updateDeadline(param: PatchDeadlineModel)
+    case editWorry(param: PatchWorryModel)
 }
 
 extension HomeService: BaseTargetType {
@@ -25,6 +26,8 @@ extension HomeService: BaseTargetType {
             return APIConstant.worry + "/\(worryId)"
         case .updateDeadline:
             return APIConstant.worry + "/deadline"
+        case .editWorry:
+            return APIConstant.worry
         }
     }
     
@@ -34,7 +37,7 @@ extension HomeService: BaseTargetType {
             return .get
         case .deleteWorry:
             return .delete
-        case .updateDeadline:
+        case .updateDeadline, .editWorry:
             return .patch
         }
     }
@@ -45,12 +48,14 @@ extension HomeService: BaseTargetType {
             return .requestPlain
         case .updateDeadline(let param):
             return .requestJSONEncodable(param)
+        case .editWorry(let param):
+            return .requestJSONEncodable(param)
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeGemList, .worryDetail, .deleteWorry, .updateDeadline:
+        case .homeGemList, .worryDetail, .deleteWorry, .updateDeadline, .editWorry:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -131,7 +131,7 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
     
     // MARK: - TemplateInfoTVCDelegate
     func didPressWritingButton(templateId: Int) {
-        let writeVC = WriteVC(type: .post)
+        let writeVC = WriteVC(type: .postDifferentTemplate)
         writeVC.modalPresentationStyle = .fullScreen
         self.present(writeVC, animated: true, completion: nil)
         writeVC.dataBind()

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -131,7 +131,7 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
     
     // MARK: - TemplateInfoTVCDelegate
     func didPressWritingButton(templateId: Int) {
-        let writeVC = WriteVC()
+        let writeVC = WriteVC(type: .post)
         writeVC.modalPresentationStyle = .fullScreen
         self.present(writeVC, animated: true, completion: nil)
         writeVC.dataBind()

--- a/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
@@ -32,3 +32,10 @@ struct PatchDeadlineModel: Codable {
     var worryId: Int
     var dayCount: Int
 }
+
+struct PatchWorryModel: Codable {
+    var worryId: Int
+    var templateId: Int
+    var title: String
+    var answers: [String]
+}

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -276,9 +276,7 @@ final class HomeWorryDetailVC: BaseVC {
         dataBind()
         input.send(worryId)
         worryDetailTV.reloadData()
-        DispatchQueue.main.async { [self] in
-            self.dismiss(animated: true)
-        }
+        self.dismiss(animated: true)
     }
 }
 // MARK: - KeyBoard

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -256,12 +256,28 @@ final class HomeWorryDetailVC: BaseVC {
     /// 데드라인 수정시 받는 notification을 관리하는 observer 추가
     func addObserver() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleDeadlineUpdate(_:)), name: NSNotification.Name("updateDeadline"), object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.didCompleteWorryEditing(_:)),
+            name: NSNotification.Name("CompleteWorryEditing"),
+            object: nil
+        )
     }
     
     /// 전달 받은 수정된 데드라인 일자로 navigationBar Title 변경
     @objc func handleDeadlineUpdate(_ notification: Notification) {
         if let userInfo = notification.userInfo, let deadline = userInfo["deadline"] as? Int {
             navigationBarView.setTitleText(text: "고민캐기 D-\(deadline)")
+        }
+    }
+    
+    @objc func didCompleteWorryEditing(_ notification: Notification) {
+        /// 수정된 데이터를 다시 받아오기 위해 ViewModel과 다시 한번 연동
+        dataBind()
+        input.send(worryId)
+        worryDetailTV.reloadData()
+        DispatchQueue.main.async { [self] in
+            self.dismiss(animated: true)
         }
     }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -90,7 +90,7 @@ final class HomeWorryEditVC: BaseVC {
             
             /// 적힌 제목을 templateContentTV의 제목으로 설정해줌
             if let worryTitle = self.worryDetail?.title {
-                writeVC.templateContentTV.tempTitle = worryTitle
+                writeVC.templateContentTV.title = worryTitle
                 }
             /// 적힌 답변을 writeVC로 보내줌
             writeVC.setTempAnswers(answers: self.worryDetail?.answers ?? [])

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -54,6 +54,8 @@ final class HomeWorryEditVC: BaseVC {
     /// writeVC Modal시에 화면에 띄어줄 제목을 담아서 보내줌
     private var templateTitleShortInfoList:
     [TemplateInfoPublisherModel] = []
+    
+    let worryPatchContent = WorryPatchManager.shared
 
     init(worryId: Int) {
         super.init(nibName: nil, bundle: nil)
@@ -81,11 +83,11 @@ final class HomeWorryEditVC: BaseVC {
     
     private func setPressAction() {
         editWorryButton.press {
-            //TODO: 고민 수정하기 -> 수정용 작성페이지(고민 상세에 있던 데이터 전달)
             let writeVC = WriteVC(type: .patch)
             writeVC.modalPresentationStyle = .fullScreen
             writeVC.modalTransitionStyle = .coverVertical
             self.present(writeVC, animated: true)
+            
             /// 적힌 제목을 templateContentTV의 제목으로 설정해줌
             if let worryTitle = self.worryDetail?.title {
                 writeVC.templateContentTV.tempTitle = worryTitle
@@ -94,6 +96,9 @@ final class HomeWorryEditVC: BaseVC {
             writeVC.setTempAnswers(answers: self.worryDetail?.answers ?? [])
             writeVC.dataBind()
             let templateId = (self.worryDetail?.templateId ?? 1) - 1
+            
+            self.worryPatchContent.worryId = self.worryId
+            self.worryPatchContent.templateId = templateId + 1
             /// 선택된 템플릿이 어떤건지 WriteVC.templateBtn에 표시해주기 위해 함수 구현
             writeVC.templateReload(templateId: templateId, templateTitle: self.templateTitleShortInfoList[templateId].templateTitle, templateInfo: self.templateTitleShortInfoList[templateId].templateDetail)
             /// 템플릿에 맞는 templateContent 보여지게끔 연동
@@ -110,7 +115,6 @@ final class HomeWorryEditVC: BaseVC {
             }
             self.present(pickerVC, animated: true)
             pickerVC.datePickerView.selectRow(abs(self.worryDetail?.dDay ?? 0) - 1, inComponent: 0, animated: true)
-            
         }
         
         deleteWorryButton.press {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -90,6 +90,10 @@ final class HomeWorryEditVC: BaseVC {
             if let worryTitle = self.worryDetail?.title {
                 writeVC.templateContentTV.tempTitle = worryTitle
                 }
+            /// 적힌 답변을 writeVC로 보내줌
+            writeVC.setTempAnswers(answers: self.worryDetail?.answers ?? [])
+            writeVC.dataBind()
+            let templateId = (self.worryDetail?.templateId ?? 1) - 1
             /// 선택된 템플릿이 어떤건지 WriteVC.templateBtn에 표시해주기 위해 함수 구현
             writeVC.templateReload(templateId: templateId, templateTitle: self.templateTitleShortInfoList[templateId].templateTitle, templateInfo: self.templateTitleShortInfoList[templateId].templateDetail)
             /// 템플릿에 맞는 templateContent 보여지게끔 연동

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -86,6 +86,10 @@ final class HomeWorryEditVC: BaseVC {
             writeVC.modalPresentationStyle = .fullScreen
             writeVC.modalTransitionStyle = .coverVertical
             self.present(writeVC, animated: true)
+            /// 적힌 제목을 templateContentTV의 제목으로 설정해줌
+            if let worryTitle = self.worryDetail?.title {
+                writeVC.templateContentTV.tempTitle = worryTitle
+                }
             /// 선택된 템플릿이 어떤건지 WriteVC.templateBtn에 표시해주기 위해 함수 구현
             writeVC.templateReload(templateId: templateId, templateTitle: self.templateTitleShortInfoList[templateId].templateTitle, templateInfo: self.templateTitleShortInfoList[templateId].templateDetail)
             /// 템플릿에 맞는 templateContent 보여지게끔 연동

--- a/KAERA/KAERA/Scenes/KaeraTabbarController.swift
+++ b/KAERA/KAERA/Scenes/KaeraTabbarController.swift
@@ -79,7 +79,7 @@ final class KaeraTabbarController: UITabBarController {
 extension KaeraTabbarController: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         if viewController.tabBarItem.tag == 1 {
-            let writeVC = WriteVC()
+            let writeVC = WriteVC(type: .post)
             writeVC.modalPresentationStyle = .fullScreen
             writeVC.modalTransitionStyle = .coverVertical
             self.present(writeVC, animated: true, completion: nil)

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -46,6 +46,7 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         setLayout()
+        addObserver()
         worryTitleTextField.delegate = self
     }
     
@@ -68,11 +69,35 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
             $0.top.equalToSuperview().offset(28.adjustedH)
             $0.trailing.equalToSuperview().offset(-16)
         }
-
+        
         dividingLine.snp.makeConstraints {
             $0.top.equalTo(worryTitleTextField.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1.adjustedW)
+        }
+    }
+    
+    private func addObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nil)
+    }
+    
+    @objc func textDidChange(noti: NSNotification) {
+        if let text = worryTitleTextField.text {
+            let maxLength = 7
+            
+            /// 마지막 문자에 한글 받침을 사용할 수 없는 문제를 해결하기 위해 변경
+            if text.count >= maxLength {
+                if let endIndex = text.index(text.startIndex, offsetBy: maxLength, limitedBy: text.endIndex) {
+                    let fixedText = text[..<endIndex]
+                    /// 공백을 추가했다가
+                    worryTitleTextField.text = String(fixedText) + " "
+                    
+                    /// 공백을 바로 제거해줌으로써 한글 받침을 쓸 수 있게 구현해준다.
+                    DispatchQueue.main.async {
+                        self.worryTitleTextField.text = String(fixedText)
+                    }
+                }
+            }
         }
     }
 }
@@ -95,7 +120,6 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
                 return true
             }
         }
-        guard textField.text!.count < 7 else { return false }
         return true
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentHeaderViewDelegate: AnyObject {
-    func textFieldDidEndEditing(newText: String)
+    func titleDidEndEditing(newText: String)
 }
 
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
@@ -107,7 +107,7 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-        delegate?.textFieldDidEndEditing(newText: worryTitleTextField.text ?? "")
+        delegate?.titleDidEndEditing(newText: worryTitleTextField.text ?? "")
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -17,6 +17,9 @@ class TemplateContentTV: UITableView {
     private var questions: [String] = []
     private var hints: [String] = []
     private var answers: [String] = []
+    private var writeType: WriteType = .post
+    
+    var tempTitle: String = ""
     
     let contentInfo = ContentInfo.shared
     
@@ -33,7 +36,8 @@ class TemplateContentTV: UITableView {
     }
     
     // MARK: - Functions
-    func setData(questions: [String], hints: [String]) {
+    func setData(type: WriteType, questions: [String], hints: [String]) {
+        self.writeType = type
         self.questions = questions
         self.hints = hints
         self.answers = Array(repeating: "", count: hints.count)
@@ -102,7 +106,7 @@ extension TemplateContentTV : UITableViewDataSource
         /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
         cell.delegate = self
         
-        cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], index: indexPath.row)
+        cell.dataBind(type: self.writeType, question: questions[indexPath.row], hint: hints[indexPath.row], index: indexPath.row)
         
         return cell
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -81,6 +81,9 @@ extension TemplateContentTV : UITableViewDataSource
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerCell = tableView.dequeueReusableHeaderFooterView(withIdentifier: TemplateContentHeaderView.className) as? TemplateContentHeaderView else { return nil }
+        
+        /// .patch(고민 수정)의 경우 제목이 이미 있으므로 이를 headerCell의 제목으로 지정해줌.
+        headerCell.worryTitleTextField.text = tempTitle
         headerCell.worryTitleTextField.becomeFirstResponder()
 
         /// headerCell에 입력된 고민 제목을 contentInfo에 담아준다.
@@ -106,8 +109,6 @@ extension TemplateContentTV : UITableViewDataSource
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    
-
     
     func textViewDidEndEditing(index: Int, newText: String) {
         answers[index] = newText

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -75,19 +75,19 @@ class TemplateContentTVC: UITableViewCell {
         }
     }
     
-    func dataBind(type: WriteType, question: String, hint: String, index: Int) {
+    func dataBind(type: WriteType, question: String, hint: String, answer: String, index: Int) {
         questionLabel.text = question
+        placeHolder = hint
+        self.indexPath = index
         /// 아래의 textViewDelegate에서 update된 placeholder를 써주기 위해 placeholder에도 hint를 담아준다.
-        if type == .post || type == .postDifferentTemplate {
-            placeHolder = hint
-            textView.text = placeHolder
-            self.indexPath = index
-        }
-        /// writeType이 .patch(고민수정) 이라면 텍스트 컬러를 white로 바꿔주어 원래 있던 텍스트가 회색으로 보여지지 않게끔 해준다.
-        else {
-            textView.textColor = .white
-            textView.text = hint
-            self.indexPath = index
+        if type == .patch {
+            textView.text = answer
+            textView.textColor = .kWhite
+        } else {
+            if answer == "" {
+                textView.text = placeHolder
+                textView.textColor = .kGray4
+            }
         }
     }
 }
@@ -122,12 +122,7 @@ extension TemplateContentTVC: UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        if trimmedText.isEmpty == true {
-            textView.text = placeHolder
-            textView.textColor = .kGray4
-        }
         if textView.textColor == .kGray4 {
             textView.text = nil
             textView.textColor = .kWhite
@@ -136,7 +131,7 @@ extension TemplateContentTVC: UITextViewDelegate {
     
     func textViewDidEndEditing(_ textView: UITextView) {
         let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-
+        
         if trimmedText.isEmpty == true {
             textView.text = placeHolder
             textView.textColor = .kGray4

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentTVCDelegate: AnyObject {
-    func textViewDidEndEditing(index: Int, newText: String)
+    func answerDidEndEditing(index: Int, newText: String)
 }
 
 class TemplateContentTVC: UITableViewCell {
@@ -78,7 +78,7 @@ class TemplateContentTVC: UITableViewCell {
     func dataBind(type: WriteType, question: String, hint: String, index: Int) {
         questionLabel.text = question
         /// 아래의 textViewDelegate에서 update된 placeholder를 써주기 위해 placeholder에도 hint를 담아준다.
-        if type == .post {
+        if type == .post || type == .postDifferentTemplate {
             placeHolder = hint
             textView.text = placeHolder
             self.indexPath = index
@@ -87,6 +87,7 @@ class TemplateContentTVC: UITableViewCell {
         else {
             textView.textColor = .white
             textView.text = hint
+            self.indexPath = index
         }
     }
 }
@@ -121,6 +122,12 @@ extension TemplateContentTVC: UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedText.isEmpty == true {
+            textView.text = placeHolder
+            textView.textColor = .kGray4
+        }
         if textView.textColor == .kGray4 {
             textView.text = nil
             textView.textColor = .kWhite
@@ -155,6 +162,6 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.endUpdates()
         }
         
-        delegate?.textViewDidEndEditing(index: self.indexPath, newText: trimmedText)
+        delegate?.answerDidEndEditing(index: self.indexPath, newText: trimmedText)
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -32,7 +32,7 @@ class TemplateContentTVC: UITableViewCell {
     private let textViewConstant: CGFloat = 111.adjustedH
     
     private var placeHolder: String = ""
-        
+            
     lazy var textView = UITextView().then {
         $0.isScrollEnabled = false
         $0.delegate = self
@@ -75,12 +75,19 @@ class TemplateContentTVC: UITableViewCell {
         }
     }
     
-    func dataBind(question: String, hint: String, index: Int) {
+    func dataBind(type: WriteType, question: String, hint: String, index: Int) {
         questionLabel.text = question
         /// 아래의 textViewDelegate에서 update된 placeholder를 써주기 위해 placeholder에도 hint를 담아준다.
-        placeHolder = hint
-        textView.text = placeHolder
-        self.indexPath = index
+        if type == .post {
+            placeHolder = hint
+            textView.text = placeHolder
+            self.indexPath = index
+        }
+        /// writeType이 .patch(고민수정) 이라면 텍스트 컬러를 white로 바꿔주어 원래 있던 텍스트가 회색으로 보여지지 않게끔 해준다.
+        else {
+            textView.textColor = .white
+            textView.text = hint
+        }
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/WorryPatchManager.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WorryPatchManager.swift
@@ -1,0 +1,20 @@
+//
+//  WorryPatchManager.swift
+//  KAERA
+//
+//  Created by saint on 2023/10/15.
+//
+
+import Foundation
+
+class WorryPatchManager {
+    static let shared = WorryPatchManager()
+
+    var worryId: Int = 1
+    var templateId: Int = 1
+    var title: String = ""
+    var answers: [String] = []
+
+    private init() { }
+}
+

--- a/KAERA/KAERA/Scenes/Writing/View/WorryPostManager.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WorryPostManager.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-class ContentInfo {
-    static let shared = ContentInfo()
+class WorryPostManager {
+    static let shared = WorryPostManager()
 
     var templateId: Int = 1
     var title: String = ""

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -123,13 +123,13 @@ class WritePickerVC: UIViewController {
                 self.postWorryContent()
             case .patch:
                 deadlineContent.worryId = self.worryId
-                deadlineContent.dayCount = contentInfo.deadline
+                deadlineContent.dayCount = worryPostContent.deadline
                 /// 서버통신 실패 시 띄울 알럿 창 구현
                 let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
                 failureAlertVC.setTitleSubTitle(title: "일자 수정에 실패했어요", subTitle: "다시 한번 시도해주세요.", highlighting: "실패")
                 self.patchWorryDeadline { success in
                     if success {
-                        NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": self.contentInfo.deadline])
+                        NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": self.deadlineContent.dayCount])
                     } else {
                         self.present(failureAlertVC, animated: true)
                         failureAlertVC.OKButton.press {

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -23,8 +23,8 @@ class WritePickerVC: UIViewController {
         $0.backgroundColor = .kGray1
     }
     
-    let contentInfo = ContentInfo.shared
-    var publishedContent = WorryContentRequestModel(templateId: 1, title: "", answers: [], deadline: -1)
+    let worryPostContent = WorryPostManager.shared
+    var worryPostPublishedContent = WorryContentRequestModel(templateId: 1, title: "", answers: [], deadline: -1)
     
     var worryId: Int = 0
     
@@ -110,22 +110,22 @@ class WritePickerVC: UIViewController {
             /// picker에서 고른 숫자를 deadline으로 설정해줌.
             let selectedRow = datePickerView.selectedRow(inComponent: 0)
             let selectedValue = pickerData[selectedRow]
-            contentInfo.deadline = Int(selectedValue) ?? -1
+            worryPostContent.deadline = Int(selectedValue) ?? -1
                         
             /// contentInfo 싱글톤 클래스에 담긴 내용을 서버로 보내주기 위해 구조체 형식으로 변환시켜줌.
-            publishedContent.templateId = contentInfo.templateId
-            publishedContent.title = contentInfo.title
-            publishedContent.answers = contentInfo.answers
-            publishedContent.deadline = contentInfo.deadline
+            worryPostPublishedContent.templateId = worryPostContent.templateId
+            worryPostPublishedContent.title = worryPostContent.title
+            worryPostPublishedContent.answers = worryPostContent.answers
+            worryPostPublishedContent.deadline = worryPostContent.deadline
             
             switch self .deadlineType {
             case .post:
                 self.postWorryContent()
             case .patch:
                 deadlineContent.worryId = self.worryId
-                deadlineContent.dayCount = contentInfo.deadline
+                deadlineContent.dayCount = worryPostContent.deadline
                 self.patchWorryDeadline()
-                NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": contentInfo.deadline])
+                NotificationCenter.default.post(name: NSNotification.Name("updateDeadline"), object: nil, userInfo: ["deadline": worryPostContent.deadline])
             }
             
             UIView.animate(withDuration: 0.5, animations: { [self] in
@@ -146,7 +146,7 @@ class WritePickerVC: UIViewController {
     
     private func postWorryContent() {
         /// 서버로 고민 내용을 POST 시켜줌
-        WriteAPI.shared.postWorryContent(param: publishedContent) { result in
+        WriteAPI.shared.postWorryContent(param: worryPostPublishedContent) { result in
             guard let result = result, let _ = result.data else { return }
         }
     }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -10,6 +10,11 @@ import Combine
 import SnapKit
 import Then
 
+enum WriteType {
+    case post
+    case patch
+}
+
 class WriteVC: BaseVC {
     
     // MARK: - View Model
@@ -94,6 +99,17 @@ class WriteVC: BaseVC {
     let contentInfo = ContentInfo.shared
     
     private let pickerVC = WritePickerVC(type: .post)
+    
+    private var writeType: WriteType = .post
+    // MARK: - Initialization
+    init(type: WriteType) {
+        super.init(nibName: nil, bundle: nil)
+        self.writeType = type
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Life Cycles
     override func viewDidLoad() {

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -24,7 +24,7 @@ class WriteVC: BaseVC {
     
     // MARK: - Properties
     private let writeModalVC = WriteModalVC()
-    private let templateContentTV = TemplateContentTV()
+    let templateContentTV = TemplateContentTV()
     private let templateHeaderView = TemplateContentHeaderView()
     
     private let closeBtn = UIButton().then {
@@ -101,6 +101,9 @@ class WriteVC: BaseVC {
     private let pickerVC = WritePickerVC(type: .post)
     
     private var writeType: WriteType = .post
+    
+    private var tempAnswers: [String] = []
+    
     // MARK: - Initialization
     init(type: WriteType) {
         super.init(nibName: nil, bundle: nil)
@@ -142,7 +145,13 @@ class WriteVC: BaseVC {
     }
     
     private func updateUI(_ templateContents: TemplateContentModel) {
-        templateContentTV.setData(questions: templateContents.questions, hints: templateContents.hints)
+        switch self .writeType {
+        case .post:
+            templateContentTV.setData(type: .post, questions: templateContents.questions, hints: templateContents.hints)
+        case .patch:
+            /// 고민상세뷰로부터 전달받은 답변을 hints로 사용
+            templateContentTV.setData(type: .patch, questions: templateContents.questions, hints: tempAnswers)
+        }
         
         view.addSubview(templateContentTV)
         templateContentTV.snp.updateConstraints {
@@ -190,6 +199,10 @@ class WriteVC: BaseVC {
             }
             self.present(self.writeModalVC, animated: true)
         }
+    }
+    
+    func setTempAnswers(answers: [String]) {
+        self.tempAnswers = answers
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
할 얘기가 많습니다 희희 생각보다 오래 걸렸네용 ㅠㅠ
이것저것 많이 추가하느라 저도 좀 헷갈려서 주석을 다 달아놓았습니다
- 고민수정 API를 연결하였습니다. 
- 고민작성뷰(WriteVC)에서 자잘한 버그들을 모두 수정하였습니다. 
1. collection뷰 세게 스크롤 시 순서 및 내용 초기화 -> TV, TVC의 지역변수에 계속 동기화해주는 것으로 해결
    - 제목 사라지는 것
    - 답변 순서 변경되는 것
    - 답변란의 내용이 placeholder로 변경되는 것
2. 템플릿 변경 기능 수정
    - 템플릿 변경 시에 템플릿 질문 및 placeholder 변경
    - 고민수정 로직에서만 템플릿 변경 시 원래 작성했던 내용으로 placeholder가 설정되게 구현
3. _고민 수정 완료 시에 고민 상세보기 뷰 초기화 (아직 수정 필요)_
    - 완료 버튼 눌렀을 때 바로 초기화가 잘 될때가 있고 안될 때가 있음. 
		-> HomeWorryDetailVC -> didCompleteWorryEditing 부분에 코드 수정 필요할듯

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
### ✅ 작업 과정
- WriteType 열거형의 case를 4가지로 나누어주었습니다. 
-> 각각의 로직마다 처리를 다르게 해주었습니다 
    - post: 고민 작성 시
    - postDifferentTemplate: 고민 작성 로직에서 템플릿 변경 시
    - patch: 고민 수정 시
      - 고민 수정시에는 고민 작성 뷰에 원래 답변이 보여지게끔 하고 그 답변이 placeholder가 될 수 있게끔 설정해주었습니다. 
    - patchDifferentTemplate: 고민 수정 로직에서 템플릿 변경 시

- post를 제외한 나머지 경우들은 템플릿 변경 시에 "템플릿 변경 알럿창"이 뜨게끔 구현하였습니다. 
    - "템플릿 변경 알럿창"에서 '변경'을 누르게 되면 템플릿 변경 시에 작성해둔 내용이 모두 사라집니다. 
    - 고민보관함뷰에서 고민작성뷰로 넘어갈 때 WriteVC 초기화를 .post에서 .postDifferentTemplate으로 변경해주었습니다. 
        -> 이미 템플릿이 있는 상태이기에

### 💡 공유하고 싶은 부분
기존의 textField의 글자수를 제한하는 부분에서 영어는 글자수 제한이 잘 작동하는데, 한글로는 글자수 제한이 조금 이상하게 됐는 것을 확인!
ex) "하늘이정말맑네"(7/7) 에서 받침에 'ㅇ' 을 추가하여 "하늘이정말맑넹" 을 치고 싶었는데, 글자수 제한 때문에 'ㅇ'이 쳐지지 않았다. 
기본적으로 Swift는 한글 문자를 분해하지 않고 길이를 체크하므로, 받침 유무에 따라 길이가 다르게 인식된다. '자음' + '모음' 에서 이미 한글자로 인식을 해버려서 받침에 들어가야 하는 추가 '자음'이 쳐지지를 않음. 

이러한 문제를 해결해주기 위해 기존 textField delegate에서 지원하는 shouldChangeCharactersIn 코드를 지우고, textField가 변경되는 것을 계속 확인하는 UITextField.textDidChangeNotification에 함수를 추가하여 해결해주었다!

- 기존 코드
``` 
textField.text!.count < 7 else { return false }
        return true
``` 

- 수정한 코드
``` 
@objc func textDidChange(noti: NSNotification) {
        if let text = worryTitleTextField.text {
            let maxLength = 7
            if text.count >= maxLength {
                if let endIndex = text.index(text.startIndex, offsetBy: maxLength, limitedBy: text.endIndex) {
                    let fixedText = text[..<endIndex]

                    worryTitleTextField.text = String(fixedText) + " "
                    
                    DispatchQueue.main.async {
                        self.worryTitleTextField.text = String(fixedText)
                    }
                }
            }
        }
    } 
```

### 🙋🏻‍♂️ 피드백을 받고 싶은 부분
위의 작업한 내용의 3번에도 적어놨듯이 고민 수정 완료 시에 어떨 때는 고민 상세보기 뷰가 잘 초기화 될 때가 있고, 어떨 때는 잘 안되는데 로직에 수정이 필요할 거 같아요! 요 부분만 좀 봐주세요!
``` 
# HomeWorryDetailVC

@objc func didCompleteWorryEditing(_ notification: Notification) {
        /// 수정된 데이터를 다시 받아오기 위해 ViewModel과 다시 한번 연동
        dataBind()
        input.send(worryId)
        worryDetailTV.reloadData()
        self.dismiss(animated: true)
    }
``` 
위의 코드에서 reloadData를 해주었는데도 불구하고 뷰 초기화가 잘 안되는거 같아여,,,ㅎㅁㅎ






## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
지금 토큰이 만료되었다고 떠서 스크린샷은 나중에 첨부할게요!
<img width="578" alt="스크린샷 2023-10-30 오전 12 45 32" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/6beb6afe-5ec4-4538-9deb-1a5db7ee0ae8">

## 🚨 관련 이슈
- Resolved: #77 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
