### PR TITLE
[Feat] 나의 기록 등록 및 수정하기 API 연결

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		E74968D62A74B84100C3C0CF /* WorryDetailReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */; };
 		E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */; };
 		E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */; };
+		E78B648B2AF85FA00046215D /* WorryReviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B648A2AF85FA00046215D /* WorryReviewModel.swift */; };
 		E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */; };
 		E79AAC212A52F19300F3F439 /* ToastMessageColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */; };
 		E79AAC302A52F2C300F3F439 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC222A52F2C200F3F439 /* String+.swift */; };
@@ -194,6 +195,7 @@
 		E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDetailReviewView.swift; sourceTree = "<group>"; };
 		E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDecisionVC.swift; sourceTree = "<group>"; };
 		E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryQuoteView.swift; sourceTree = "<group>"; };
+		E78B648A2AF85FA00046215D /* WorryReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryReviewModel.swift; sourceTree = "<group>"; };
 		E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastMessageColorType.swift; sourceTree = "<group>"; };
 		E79AAC222A52F2C200F3F439 /* String+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				E7B94D792ADEB403005D9FB8 /* MyPageTVCModel.swift */,
 				E7B94D7B2AE00C42005D9FB8 /* PushSettingInfo.swift */,
 				E7DE36232AE4F59900B0DC67 /* MyPageDataType.swift */,
+				E78B648A2AF85FA00046215D /* WorryReviewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -943,6 +946,7 @@
 				85EBC7F12A5AD7BC00B9E891 /* KaeraTabbarController.swift in Sources */,
 				E7AC12212A51CFFD00FE504C /* GeneralResponse.swift in Sources */,
 				E79AAC382A52F2C300F3F439 /* UIStackView+.swift in Sources */,
+				E78B648B2AF85FA00046215D /* WorryReviewModel.swift in Sources */,
 				E7C808EB2A4D37F800F475CE /* SceneDelegate.swift in Sources */,
 				85887D822A5C429F00F7FB21 /* WriteModalVC.swift in Sources */,
 				E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */,

--- a/KAERA/KAERA/Application/KeyChainManager.swift
+++ b/KAERA/KAERA/Application/KeyChainManager.swift
@@ -88,6 +88,12 @@ final class KeychainManager {
             print("delete \(key.rawValue) success")
         } else {
             print("delete \(key.rawValue) failed")
+            printDescription(status: status)
+        }
+    }
+    class func printDescription(status: OSStatus) {
+        if let desctiption = SecCopyErrorMessageString(status, nil) {
+            print(desctiption)
         }
     }
     

--- a/KAERA/KAERA/Network/APIs/AuthAPI.swift
+++ b/KAERA/KAERA/Network/APIs/AuthAPI.swift
@@ -18,6 +18,8 @@ final class AuthAPI {
     public private(set) var kakaoLoginResponse: GeneralResponse<SignInModel>?
     public private(set) var renewalResponse: GeneralResponse<RenewalTokenModel>?
     public private(set) var kakaoLogoutResponse: EmptyResponse?
+    public private(set) var appleSignInResponse: GeneralResponse<SignInModel>?
+    
     
     func postKakaoLogin(token: String, completion: @escaping (GeneralResponse<SignInModel>?) -> ()) {
         authProvider.request(.kakaoLogin(token: token)) { [weak self] response in
@@ -75,6 +77,25 @@ final class AuthAPI {
                     default:
                         completion(nil)
                     }
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func postAppleSignIn(body: AppleSignInRequestBody, completion: @escaping (GeneralResponse<SignInModel>?) -> ()) {
+        authProvider.request(.appleLogin(body: body)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.appleSignInResponse = try result.map(GeneralResponse<SignInModel>?.self)
+                    guard let res = self?.appleSignInResponse else { return }
+                    completion(res)
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -21,6 +21,7 @@ final class HomeAPI {
     public private(set) var updateDeadlineResponse: GeneralResponse<String>?
     public private(set) var editWorryResponse: GeneralResponse<String>?
     public private(set) var completeWorryResponse: GeneralResponse<QuoteModel>?
+    public private(set) var worryReviewResponse: GeneralResponse<WorryReviewResponseModel>?
    
     // MARK: - HomeGemList
     func getHomeGemList(param: Int, completion: @escaping (GeneralArrayResponse<HomeGemListModel>?) -> ()) {
@@ -135,6 +136,32 @@ final class HomeAPI {
                     default:
                         completion(nil)
                     }
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - putReview
+    func putReview(body: WorryReviewRequestBody, completion: @escaping (GeneralResponse<WorryReviewResponseModel>?) -> ()) {
+        homeProvider.request(.putReview(body: body)) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.worryReviewResponse = try result.map(GeneralResponse<WorryReviewResponseModel>?.self)
+                    guard let res = self?.worryReviewResponse else { return }
+                    switch res.status {
+                    case 200..<300:
+                        completion(res)
+                    default:
+                        completion(nil)
+                    }
+
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -27,4 +27,5 @@ struct APIConstant {
     static let kakaoLogin = "/auth/kakao/login"
     static let refresh = "/auth/token/refresh"
     static let logout = "/auth/logout"
+    static let appleLogin = "/auth/apple/login"
 }

--- a/KAERA/KAERA/Network/Services/AuthService.swift
+++ b/KAERA/KAERA/Network/Services/AuthService.swift
@@ -12,22 +12,10 @@ enum AuthService {
     case kakaoLogin(token: String)
     case kakaoLogout
     case renewelToken
+    case appleLogin(body: AppleSignInRequestBody)
 }
 
 extension AuthService: BaseTargetType {
-    
-    struct SignInRequestBody: Codable {
-        let accessToken: String
-    }
-    
-    struct RenewalRequestBody: Codable {
-        let accessToken: String
-        let refreshToken: String
-    }
-    
-    struct SignOutRequestBody: Codable {
-        let accessToken: String
-    }
 
     var path: String {
         switch self {
@@ -37,12 +25,14 @@ extension AuthService: BaseTargetType {
             return APIConstant.refresh
         case .kakaoLogout:
             return APIConstant.logout
+        case .appleLogin:
+            return APIConstant.appleLogin
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .kakaoLogin, .renewelToken, .kakaoLogout:
+        case .kakaoLogin, .renewelToken, .kakaoLogout, .appleLogin:
             return .post
         }
     }
@@ -50,7 +40,7 @@ extension AuthService: BaseTargetType {
     var task: Moya.Task {
         switch self {
         case .kakaoLogin(let token):
-            let requsetBody = SignInRequestBody(accessToken: token)
+            let requsetBody = KakaoSignInRequestBody(accessToken: token)
             return .requestJSONEncodable(requsetBody)
             
         case .renewelToken:
@@ -61,12 +51,15 @@ extension AuthService: BaseTargetType {
             
         case .kakaoLogout:
             return .requestPlain
+        
+		case .appleLogin(let body):
+            return .requestJSONEncodable(body)
         }
     }
     
     var headers: [String : String]? {
         switch self {
-        case .kakaoLogin, .renewelToken:
+        case .kakaoLogin, .renewelToken, .appleLogin:
             return NetworkConstant.noTokenHeader
         case .kakaoLogout:
             return NetworkConstant.hasTokenHeader

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -15,6 +15,7 @@ enum HomeService {
     case updateDeadline(param: PatchDeadlineModel)
     case editWorry(param: PatchWorryModel)
     case completeWorry(param: CompleteWorryModel)
+    case putReview(body: WorryReviewRequestBody)
 }
 
 extension HomeService: BaseTargetType {
@@ -31,6 +32,8 @@ extension HomeService: BaseTargetType {
             return APIConstant.worry
         case .completeWorry:
             return APIConstant.worry + "/finalAnswer"
+        case .putReview:
+            return APIConstant.review
         }
     }
     
@@ -42,6 +45,8 @@ extension HomeService: BaseTargetType {
             return .delete
         case .updateDeadline, .editWorry, .completeWorry:
             return .patch
+        case .putReview:
+            return .put
         }
     }
     
@@ -55,12 +60,14 @@ extension HomeService: BaseTargetType {
             return .requestJSONEncodable(param)
         case .completeWorry(let param):
             return .requestJSONEncodable(param)
+        case .putReview(let body):
+            return .requestJSONEncodable(body)
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .homeGemList, .worryDetail, .deleteWorry, .updateDeadline, .editWorry, .completeWorry:
+        case .homeGemList, .worryDetail, .deleteWorry, .updateDeadline, .editWorry, .completeWorry, .putReview:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Auth/Model/SignInModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/Model/SignInModel.swift
@@ -17,3 +17,18 @@ struct SignInModel: Codable {
 enum LoginType {
     case kakao, apple
 }
+
+struct RenewalRequestBody: Codable {
+    let accessToken: String
+    let refreshToken: String
+}
+
+struct KakaoSignInRequestBody: Codable {
+    let accessToken: String
+}
+
+struct AppleSignInRequestBody: Codable {
+    let identityToken: String
+    let user: String
+    let fullName: String
+}

--- a/KAERA/KAERA/Scenes/Auth/Model/WorryReviewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/Model/WorryReviewModel.swift
@@ -1,0 +1,17 @@
+//
+//  WorryReviewMdoel.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/11/06.
+//
+
+import Foundation
+
+struct WorryReviewRequestBody: Codable {
+    let worryId: Int
+    let review: String
+}
+
+struct WorryReviewResponseModel: Codable {
+    let updatedAt: String
+}

--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -73,21 +73,29 @@ final class SignInViewModel: NSObject, ViewModelType {
 // MARK: - Network
 extension SignInViewModel {
     private func postKakaoLogin(token: String) {
-        AuthAPI.shared.postKakaoLogin(token: token) { res in
+        AuthAPI.shared.postKakaoLogin(token: token) { [weak self] res in
             guard let res, let data = res.data else {
-                self.output.send(false)
+                self?.output.send(false)
                 return
             }
             
             /// user info 저장
             KeychainManager.saveUserInfo(id: "\(data.id)", userName: data.name, accessToken: data.accessToken, refreshToken: data.refreshToken)
             
-            self.output.send(true)
+            self?.output.send(true)
         }
     }
     
-    private func postAppleLogin(token: String) {
-        print("아이덴티티토큰", token)
+    private func postAppleSignIn(body: AppleSignInRequestBody) {
+        AuthAPI.shared.postAppleSignIn(body: body) { [weak self] res in
+            guard let data = res?.data else {
+                self?.output.send(false)
+                return
+            }
+            KeychainManager.saveUserInfo(id: "\(data.id)", userName: data.name,accessToken: data.accessToken, refreshToken: data.refreshToken)
+            
+            self?.output.send(true)
+        }
     }
 }
 
@@ -99,20 +107,20 @@ extension SignInViewModel: ASAuthorizationControllerDelegate {
         switch authorization.credential {
             
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-            if let email = appleIDCredential.email {
-                print("이메일", email)
-            }
-            if let fullName = appleIDCredential.fullName {
-                print("풀네임", fullName)
-            }
+            
+            let user = appleIDCredential.user
+            let fullName = appleIDCredential.fullName
+            
+            /// 이름을 못받을 경우 "해라"로 기입 될 수 있게 수정
+            let userName = (fullName?.familyName ?? "") + (fullName?.givenName ?? "해라")
+            
             if let identityToken = appleIDCredential.identityToken,
                let tokenString = String(data: identityToken, encoding: .utf8) {
-                postAppleLogin(token: tokenString)
-            }
-            
-            if let authorizationCode = appleIDCredential.authorizationCode {
-                let authorizationCodeString = String(data: authorizationCode, encoding: .utf8)
-                print("인가코드", authorizationCodeString)
+                
+                // fullName이 nil일 경우 "해라"로 대체
+                let requestBody = AppleSignInRequestBody(identityToken: tokenString, user: user, fullName: userName)
+                
+                postAppleSignIn(body: requestBody)
             }
            
         default:

--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -117,7 +117,6 @@ extension SignInViewModel: ASAuthorizationControllerDelegate {
             if let identityToken = appleIDCredential.identityToken,
                let tokenString = String(data: identityToken, encoding: .utf8) {
                 
-                // fullName이 nil일 경우 "해라"로 대체
                 let requestBody = AppleSignInRequestBody(identityToken: tokenString, user: user, fullName: userName)
                 
                 postAppleSignIn(body: requestBody)

--- a/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
+++ b/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
@@ -151,6 +151,12 @@ final class KaeraAlertVC: BaseVC {
         }
     }
     
+    func addCancelPressAction(completion: @escaping () -> ()) {
+        cancelButton.press {
+            completion()
+        }
+    }
+    
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
+++ b/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
@@ -139,7 +139,7 @@ final class KaeraAlertVC: BaseVC {
         self.modalTransitionStyle = .crossDissolve
     }
     
-    func setCancelButtonAction() {
+    private func setCancelButtonAction() {
         if buttonType == .onlyOK {
             OKButton.press { [weak self] in
                 self?.dismiss(animated: true)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -277,7 +277,6 @@ final class HomeWorryDetailVC: BaseVC {
     
     @objc func didCompleteWorryEditing(_ notification: Notification) {
         /// 수정된 데이터를 다시 받아오기 위해 ViewModel과 다시 한번 연동
-        dataBind()
         input.send(worryId)
         worryDetailTV.reloadData()
         self.dismiss(animated: true)
@@ -297,6 +296,9 @@ final class HomeWorryDetailVC: BaseVC {
             self?.dismiss(animated: true) {
                 self?.view.endEditing(true)
             }
+        }
+        alertVC.addCancelPressAction { [weak self] in
+            self?.reviewView.reviewTextView.becomeFirstResponder()
         }
         self.present(alertVC, animated: true)
     }
@@ -351,7 +353,7 @@ extension HomeWorryDetailVC {
 // MARK: - Network
 extension HomeWorryDetailVC {
     func putReviewText() {
-        let reviewText = reviewView.reviewTextView.text ?? ""
+        self.reviewText = reviewView.reviewTextView.text ?? ""
         let reviewModel = WorryReviewRequestBody(worryId: worryId, review: reviewText)
         
         HomeAPI.shared.putReview(body: reviewModel) { [weak self] res in

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -350,6 +350,8 @@ extension HomeWorryDetailVC {
         isReviewEditing = false
     }
 }
+
+//TODO: 뷰모델로 데이터 처리를 넘기도록 리팩토링!
 // MARK: - Network
 extension HomeWorryDetailVC {
     func putReviewText() {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
@@ -20,7 +20,7 @@ final class WorryDetailReviewView: UIView {
                                       range: (text as NSString).range(of: "나의 기록"))
         $0.attributedText = attributedString
     }
-
+    
     let reviewTextView = UITextView().then {
         $0.textColor = .kGray5
         $0.font = .kSb2R12W
@@ -41,6 +41,7 @@ final class WorryDetailReviewView: UIView {
         super.init(frame: frame)
         setUI()
         setLayout()
+        setKeyboardButton()
     }
     
     required init?(coder: NSCoder) {
@@ -56,6 +57,37 @@ final class WorryDetailReviewView: UIView {
             reviewTextView.text = "이 고민을 통해 배운점 또는 생각을 자유롭게 적어보세요"
         }
     }
+    
+    private let saveButton = UIButton().then {
+        $0.setTitle("저장", for: .normal)
+        $0.setTitleColor(.kWhite, for: .normal)
+    }
+    private func setKeyboardButton() {
+        let spacerBarButton = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let saveBarButton = UIBarButtonItem.init(customView: saveButton)
+        let toolBar = UIToolbar()
+        toolBar.barTintColor = .kGray2
+        toolBar.sizeToFit()
+        
+        toolBar.items = [spacerBarButton, saveBarButton]
+        
+        reviewTextView.inputAccessoryView = toolBar
+    }
+    
+    func setPressAction(completion: @escaping () -> ()) {
+        saveButton.press {
+            completion()
+        }
+    }
+    
+    func updateReviewContent(text: String) {
+        self.reviewTextView.text = text
+    }
+    
+    func updateReviewDate(date: String) {
+        self.reviewDateLabel.text = date
+    }
+
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/Splash/View/SplashVC.swift
+++ b/KAERA/KAERA/Scenes/Splash/View/SplashVC.swift
@@ -29,7 +29,6 @@ final class SplashVC: BaseVC {
         super.viewDidLoad()
         setUI()
         setDissolveAnimation()
-
     }
     
     private func setDissolveAnimation() {


### PR DESCRIPTION
## 💪 작업한 내용
- 나의 기록 등록 및 수정하기 API 연결
-  키보드 위 저장버튼 구현
  - 저장 버튼 눌러서 서버통신 성공시 토스트 메시지로 저장완료 띄우기
- 기타 키보드, 알럿창 관련 UI 처리


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 1차로 노션 명세서에는 Patch로 되어있어서 Patch 서버 통신했다가 실패해서 알고보니 Put이였던거에서 삽질하고..
- 2차로 명세서에는 response에 updatedAt 데이터가 있는데 테스트 할때는 data 없는 리스폰스가 와서 디버깅하다가 삽질했는데 알고보니 고민캐기 이후 첫 나의 기록 등록 요청시 첫 리스폰스는 data가 없는걸로 오더군요 해당 부분은 일단 서버쪽에 수정 요청했습니다.

- 피그마에는 나의 기록 저장 버튼 만있고 언제 저장 안하고 취소할건지 묻는 알림을 띄우는지 명시가 안되어 있어서!!ㅋ 임의로 텍스트뷰 밖 영역 터치시 알럿 띄우거
  - 삭제시 원래 텍스트로 돌아가고 키보드 내림
  - 취소시 수정중인 텍스트 그대로 두고, 키보드 올림

🚨 시간이 없어서.. 뷰모델에서 처리해줘야하는 로직들을 VC에서 구현해줬습니다. 추후에 수정하겠습니다!

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 기록 저장 | 기록 취소 알럿 |
| --------- | ---------- |
| ![Simulator Screen Recording - iPhone 13 mini - 2023-11-06 at 21 53 22](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/1dbb877f-43ac-4964-bd32-f8c06a75b2ea) | ![Simulator Screen Recording - iPhone 13 mini - 2023-11-06 at 21 53 40](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/6d7c76f0-1b3d-4905-8a65-b5147851bb18) |


## 🚨 관련 이슈
- Resolved: #86 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
