### PR TITLE
[Feat] 고민개수 12개일때 고민작성 제한

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		E74968D62A74B84100C3C0CF /* WorryDetailReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */; };
 		E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */; };
 		E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */; };
+		E772E70D2AF9AE650098E091 /* HomeGemStoneCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */; };
 		E78B648B2AF85FA00046215D /* WorryReviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B648A2AF85FA00046215D /* WorryReviewModel.swift */; };
 		E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */; };
 		E79AAC212A52F19300F3F439 /* ToastMessageColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */; };
@@ -195,6 +196,7 @@
 		E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDetailReviewView.swift; sourceTree = "<group>"; };
 		E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDecisionVC.swift; sourceTree = "<group>"; };
 		E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryQuoteView.swift; sourceTree = "<group>"; };
+		E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemStoneCount.swift; sourceTree = "<group>"; };
 		E78B648A2AF85FA00046215D /* WorryReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryReviewModel.swift; sourceTree = "<group>"; };
 		E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		E79AAC202A52F19300F3F439 /* ToastMessageColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastMessageColorType.swift; sourceTree = "<group>"; };
@@ -656,6 +658,7 @@
 				E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */,
 				E7FEC0992A6D1725006F36BF /* WorryDetailModel.swift */,
 				85831C312AF0F5F2008839A0 /* CompleteWorryModel.swift */,
+				E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -946,6 +949,7 @@
 				85EBC7F12A5AD7BC00B9E891 /* KaeraTabbarController.swift in Sources */,
 				E7AC12212A51CFFD00FE504C /* GeneralResponse.swift in Sources */,
 				E79AAC382A52F2C300F3F439 /* UIStackView+.swift in Sources */,
+				E772E70D2AF9AE650098E091 /* HomeGemStoneCount.swift in Sources */,
 				E78B648B2AF85FA00046215D /* WorryReviewModel.swift in Sources */,
 				E7C808EB2A4D37F800F475CE /* SceneDelegate.swift in Sources */,
 				85887D822A5C429F00F7FB21 /* WriteModalVC.swift in Sources */,

--- a/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
+++ b/KAERA/KAERA/Scenes/Components/KaeraAlertVC.swift
@@ -131,6 +131,12 @@ final class KaeraAlertVC: BaseVC {
         titleLabel.sizeToFit()
 
         subTitleLabel.text = subTitle
+        let attrString = NSMutableAttributedString(string: subTitle)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        subTitleLabel.attributedText = attrString
         subTitleLabel.sizeToFit()
     }
     
@@ -181,7 +187,7 @@ extension KaeraAlertVC {
         }
         
         buttonStackView.snp.makeConstraints {
-            $0.height.equalTo(60)
+            $0.height.equalTo(58.adjustedH)
             $0.left.right.bottom.equalToSuperview()
         }
     }

--- a/KAERA/KAERA/Scenes/Home/Model/HomeGemStoneCount.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/HomeGemStoneCount.swift
@@ -1,0 +1,17 @@
+//
+//  HomeGemStoneCount.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/11/07.
+//
+
+import Foundation
+
+class HomeGemStoneCount {
+    
+    static let shared = HomeGemStoneCount()
+    
+    var count: Int = 0
+    
+    private init() {}
+}

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -102,6 +102,7 @@ final class HomeGemStoneVC: BaseVC {
         )
         output.receive(on: DispatchQueue.main)
             .sink { [weak self] list in
+                HomeGemStoneCount.shared.count = list.count
                 self?.updateUI(gemList: list)
             }.store(in: &cancellables)
     }

--- a/KAERA/KAERA/Scenes/KaeraTabbarController.swift
+++ b/KAERA/KAERA/Scenes/KaeraTabbarController.swift
@@ -79,10 +79,16 @@ final class KaeraTabbarController: UITabBarController {
 extension KaeraTabbarController: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         if viewController.tabBarItem.tag == 1 {
-            let writeVC = WriteVC(type: .post)
-            writeVC.modalPresentationStyle = .fullScreen
-            writeVC.modalTransitionStyle = .coverVertical
-            self.present(writeVC, animated: true, completion: nil)
+            if HomeGemStoneCount.shared.count >= 12 {
+                let alertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "알겠어요!")
+                alertVC.setTitleSubTitle(title: "고민 원석이 가득찼어요!", subTitle: "너무 많은 고민은 머릿 속을 어지럽혀요 \n다른 고민들을 끝낸 다음, 새 원석을 생성할 수 있어요")
+                self.present(alertVC, animated: true)
+            }else {
+                let writeVC = WriteVC(type: .post)
+                writeVC.modalPresentationStyle = .fullScreen
+                writeVC.modalTransitionStyle = .coverVertical
+                self.present(writeVC, animated: true, completion: nil)
+            }
             return false // 탭 변경을 막음
         }
         return true // 다른 탭은 정상적으로 변경


### PR DESCRIPTION
## 💪 작업한 내용
- 고민개수 12개일때 고민작성 제한
  - 싱글톤 클래스에 서버로 부터 받은 고민중 고민 개수를 저장
  - 탭바컨트롤러에서 고민작성으로 화면 전환이 이뤄지기 때문에 2번째 탭 클릭시 싱글톤에 저장된 고민 개수에 따라 작성을 제한 할지 판단 (고민중 고민이 12개 이상일때는 알림 팝업)
  - alertVC subTitleLabel 의 행간을 늘림


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-11-07 at 08 56 55](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/587e91a7-0ac3-44be-856a-1a95c188283b)


## 🚨 관련 이슈
- Resolved: #89 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
