### PR TITLE
[Chore] 1차 QA 반영(UI)

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -79,11 +79,13 @@ class ArchiveVC: UIViewController, RefreshListDelegate {
         
         archiveHeaderView.setLeftButtonPressAction { [weak self] in
             let templateInfoVC = TemplateInfoVC()
+            templateInfoVC.hidesBottomBarWhenPushed = true
             self?.navigationController?.pushViewController(templateInfoVC, animated: true)
         }
         
         archiveHeaderView.setRightButtonPressAction { [weak self] in
             let myPageVC = MyPageVC()
+            myPageVC.hidesBottomBarWhenPushed = true
             self?.navigationController?.pushViewController(myPageVC, animated: true)
         }
     }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -115,7 +115,16 @@ final class HomeWorryEditVC: BaseVC {
             pickerVC.completeWritingBtn.press {
                 self.dismiss(animated: true)
             }
-            self.present(pickerVC, animated: true)
+            pickerVC.view.alpha = 0 /// pickerView를 초기에 보이지 않게 설정
+            ///
+            pickerVC.modalPresentationStyle = .overCurrentContext
+            self.present(pickerVC, animated: false, completion: { /// 애니메이션을 false로 설정
+                UIView.animate(withDuration: 0.5, animations: { /// 애니메이션 추가
+                    pickerVC.view.alpha = 1 /// pickerView가 서서히 보이게 설정
+                    pickerVC.view.layoutIfNeeded()
+                })
+            })
+            
             pickerVC.datePickerView.selectRow(abs(self.worryDetail?.dDay ?? 0) - 1, inComponent: 0, animated: true)
         }
         

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -98,9 +98,8 @@ final class WorryDecisionVC: BaseVC {
             self.completeWorry { success in
                 print("성공 여부", success)
                 if success {
+                    self.quoteView.setGemImage(templateId: self.templateId)
                     self.showWorryQuote()
-                    self.archiveVC.dataBind()
-                    self.archiveVC.refreshList(templateTitle: "모든 보석 보기", templateId: 0)
                 /// 서버통신 실패 시 "고민 보석 캐기 실패" 알럿창 띄우기
                 } else {
                     let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryQuoteView.swift
@@ -50,6 +50,25 @@ final class WorryQuoteView: UIView {
         )
         subTitleLabel.attributedText = attributedText
     }
+    
+    func setGemImage(templateId: Int) {
+        switch templateId {
+        case 1:
+            gemImage.image = UIImage(named: "gem_blue_l")
+        case 2:
+            gemImage.image = UIImage(named: "gem_red_l")
+        case 3:
+            gemImage.image = UIImage(named: "gem_orange_l")
+        case 4:
+            gemImage.image = UIImage(named: "gem_green_l")
+        case 5:
+            gemImage.image = UIImage(named: "gem_pink_l")
+        case 6:
+            gemImage.image = UIImage(named: "gem_yellow_l")
+        default:
+            gemImage.image = UIImage(named: "gem_blue_l")
+        }
+    }
 }
 
 // MARK: - UI

--- a/KAERA/KAERA/Scenes/KaeraTabbarController.swift
+++ b/KAERA/KAERA/Scenes/KaeraTabbarController.swift
@@ -72,6 +72,7 @@ final class KaeraTabbarController: UITabBarController {
         
         // 탭바의 테두리를 설정합니다.
         tabBar.layer.cornerRadius = 30
+        tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -14,10 +14,14 @@ enum DeadlineType {
     case patch
 }
 
-class WritePickerVC: UIViewController {
+class WritePickerVC: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Properties
     let pickerData = Array(1...30).map { String($0) }
+    
+    let pickerViewLayout = UIView().then {
+        $0.backgroundColor = .kGray1
+    }
     
     let datePickerView = UIPickerView().then {
         $0.backgroundColor = .kGray1
@@ -104,6 +108,7 @@ class WritePickerVC: UIViewController {
         setLayout()
         pressBtn()
         setDelegate()
+        addTabGesture()
     }
     
     // MARK: - Functions
@@ -173,13 +178,43 @@ class WritePickerVC: UIViewController {
             }
         }
     }
+    
+    private func addTabGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
+        tapGesture.delegate = self
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func backgroundTapped() {
+        UIView.animate(withDuration: 0.5, animations: {
+            self.pickerViewLayout.alpha = 0
+            self.view.layoutIfNeeded()
+        }) { _ in
+            self.dismiss(animated: false, completion: nil)
+        }
+    }
+    
+    // MARK: - tabGesture Delegate
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        // 터치영역이 pickerViewLayout이 아닌 경우에만 true를 반환
+        return !(touch.view?.isDescendant(of: pickerViewLayout) ?? false)
+    }
 }
 
 // MARK: - Layout
 extension WritePickerVC {
     private func setLayout() {
         view.backgroundColor = .black.withAlphaComponent(0.5)
-        view.addSubviews([datePickerView, upperCover, pickerViewTitle, lowerCover, completeWritingBtn, noDeadlineBtn])
+        view.addSubview(pickerViewLayout)
+        
+        pickerViewLayout.addSubviews([datePickerView, upperCover, pickerViewTitle, lowerCover, completeWritingBtn, noDeadlineBtn])
+        
+        pickerViewLayout.snp.makeConstraints {
+            $0.width.equalTo(358.adjustedW)
+            $0.height.equalTo(360.adjustedW)
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
         
         /// datepickerView 관련 Component
         datePickerView.addSubviews([firstLabel, secondLabel])
@@ -188,7 +223,7 @@ extension WritePickerVC {
             $0.width.equalTo(358.adjustedW)
             $0.height.equalTo(136.adjustedW)
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().offset(302.adjustedW)
+            $0.centerY.equalToSuperview()
         }
         
         firstLabel.snp.makeConstraints {


### PR DESCRIPTION
## 💪 작업한 내용
QA 이후 논의사항 반영했습니다. 
1. 네비게이션 바의 최하단 모서리 둥글게 처리 안되게 변경
2. 설정, 가이드 페이지에서 네비게이션 바 hidden 처리
3. 고민 완료 시에 고민 템플릿의 원석 id와 고민 완료 시 뜨는 팝업창의 보석 id를 동일하게 변경
  -> 고민의 종류와 관계 없이 항상 주황색 보석만 뜨는 오류를 수정
4. pickerVC 외부 영역 클릭시 pickerVC dismiss 구현


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- UI 적으로 변경할 부분이랑 Logic 적으로 변경할 부분을 나누어 수정을 진행했습니다. 


## 📸 스크린샷
#### 1. 네비게이션 바의 최하단 모서리 둥글게 처리 안되게 변경

| 변경 전 | 변경 후 |
| --------- | ---------- |
| <img width="400" alt="스크린샷 2023-11-12 오후 3 58 18" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/7b176b2b-dc04-4293-8aab-14679b623a5d"> | <img width="400" alt="스크린샷 2023-11-12 오후 3 57 31" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/e318c8c2-08aa-425f-bab2-ff64d305c0d0"> |

| 설정,가이드 페이지 tabBar hidden 처리 | 고민 명언 보석 변경 | pickerView dismiss 설정 |
| --------- | ---------- | ---------- |
| ![Simulator Screen Recording - iPhone 13 mini - 2023-11-12 at 16 03 19](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/6f44e1a8-c5d4-4690-af62-cead25fd2122) | ![Simulator Screen Recording - iPhone 13 mini - 2023-11-12 at 16 03 45](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/0011340b-3b9a-4edc-9055-1403b0041091) | ![Simulator Screen Recording - iPhone 13 mini - 2023-11-12 at 16 04 14](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/fe73945d-4ad0-414f-9dad-1688387cd9fb) |








<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
## 🚨 관련 이슈
- Resolved: #93 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
