### PR TITLE
[Chore] 1차 QA 반영(Logic)

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoHeaderView.swift
@@ -54,6 +54,8 @@ extension TemplateInfoHeaderView {
         self.addSubviews([bgImage, jewelImage, instaLabel, instaBtn])
         
         bgImage.snp.makeConstraints {
+            $0.width.equalTo(342.adjustedW)
+            $0.height.equalTo(168.adjustedW)
             $0.edges.equalToSuperview()
         }
         

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -145,7 +145,7 @@ class TemplateInfoVC: UIViewController, TemplateInfoTVCDelegate {
 extension TemplateInfoVC{
     func setLayout() {
         view.backgroundColor = .kGray1
-        view.addSubViews([titleLabel, backBtn, headerView, templateInfoTV])
+        view.addSubViews([titleLabel, backBtn, templateInfoTV])
         
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(24.adjustedW)
@@ -159,15 +159,8 @@ extension TemplateInfoVC{
             $0.height.equalTo(24)
         }
         
-        headerView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedW)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(342.adjustedW)
-            $0.height.equalTo(168.adjustedW)
-        }
-        
         templateInfoTV.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom).offset(16.adjustedW)
+            $0.top.equalTo(backBtn.snp.bottom).offset(20.adjustedW)
             $0.leading.equalTo(self.view.safeAreaLayoutGuide).offset(16.adjustedW)
             $0.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-16.adjustedW)
             $0.bottom.equalToSuperview().offset(-20.adjustedW)
@@ -180,11 +173,18 @@ extension TemplateInfoVC: UITableViewDelegate {
     
     /// tableView와 Header 사이에 생기는 공백을 제거해주기 위해 빈뷰를 추가
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return UIView()
+        let containerView = UIView()
+        containerView.addSubview(headerView)
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(containerView)
+            $0.bottom.equalTo(containerView).offset(-32)
+            $0.leading.trailing.equalTo(containerView)
+        }
+        return containerView
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
+        return 200
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/KAERA/KAERA/Scenes/Components/CustomNavigationBarView.swift
+++ b/KAERA/KAERA/Scenes/Components/CustomNavigationBarView.swift
@@ -91,14 +91,26 @@ final class CustomNavigationBarView: UIView {
     
     private func setupDoneButton() {
         rightButton.setTitleWithCustom("완료", font: .kB4R14, color: .black, for: .normal)
-        rightButton.setTitleColor(.kWhite, for: .disabled)
-        rightButton.setTitleColor(.kGray1, for: .normal)
+        rightButton.setTitleWithCustom("완료", font: .kB4R14, color: .white, for: .disabled)
         rightButton.setBackgroundColor(.kGray3, for: .disabled)
         rightButton.setBackgroundColor(.kYellow1, for: .normal)
         rightButton.layer.cornerRadius = 12
         rightButton.snp.updateConstraints {
             $0.width.equalTo(50)
             $0.height.equalTo(26)
+        }
+    }
+    
+    func setupDoneButtonStatus(type: Bool) {
+        rightButton.isEnabled = !type
+        if type {
+            /// 제목이 비어있으면 완료 버튼 비활성화
+            rightButton.setTitleColor(.kWhite, for: .disabled)
+            rightButton.backgroundColor = .kGray3
+        } else {
+            /// 제목이 있으면 완료 버튼 활성화
+            rightButton.setTitleColor(.kGray1, for: .normal)
+            rightButton.backgroundColor = .kYellow1
         }
     }
     

--- a/KAERA/KAERA/Scenes/Components/CustomNavigationBarView.swift
+++ b/KAERA/KAERA/Scenes/Components/CustomNavigationBarView.swift
@@ -101,9 +101,9 @@ final class CustomNavigationBarView: UIView {
         }
     }
     
-    func setupDoneButtonStatus(type: Bool) {
-        rightButton.isEnabled = !type
-        if type {
+    func setupDoneButtonStatus(status: Bool) {
+        rightButton.isEnabled = !status
+        if status {
             /// 제목이 비어있으면 완료 버튼 비활성화
             rightButton.setTitleColor(.kWhite, for: .disabled)
             rightButton.backgroundColor = .kGray3

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -10,6 +10,10 @@ import Combine
 import SnapKit
 import Then
 
+protocol ActivateButtonDelegate: AnyObject {
+    func isTitleEmpty(check: Bool)
+}
+
 class TemplateContentTV: UITableView {
     
     // MARK: - Properties
@@ -24,6 +28,8 @@ class TemplateContentTV: UITableView {
     
     let worryPostContent = WorryPostManager.shared
     let worryPatchContent = WorryPatchManager.shared
+    
+    weak var buttonDelegate: ActivateButtonDelegate?
     
     // MARK: - Life Cycle
     init() {
@@ -137,6 +143,7 @@ extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentT
         self.title = newText
         worryPostContent.title = title
         worryPatchContent.title = title
+        buttonDelegate?.isTitleEmpty(check: title.isEmpty)
     }
     
     func answerDidEndEditing(index: Int, newText: String) {

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -29,19 +29,6 @@ class WriteVC: BaseVC {
     let templateContentTV = TemplateContentTV()
     private let templateHeaderView = TemplateContentHeaderView()
     
-    private let closeBtn = UIButton().then {
-        $0.setBackgroundImage(UIImage(named: "icn_close"), for: .normal)
-        $0.contentMode = .scaleAspectFit
-    }
-    
-    private let completeBtn = UIButton().then {
-        $0.backgroundColor = .kGray3
-        $0.titleLabel?.font = .kB4R14
-        $0.setTitle("완료", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.layer.cornerRadius = 12
-    }
-    
     private let navigationBarView = CustomNavigationBarView(leftType: .close, rightType: .done, title: "")
     
     let templateBtn = UIButton().then {
@@ -121,9 +108,11 @@ class WriteVC: BaseVC {
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
-        writeModalVC.sendTitleDelegate = self
+        /// 초기에 완료 상태 비활성화
+        navigationBarView.setupDoneButtonStatus(type: true)
         setNaviButtonAction()
         setLayout()
+        setDelegate()
         pressBtn()
         hideKeyboardWhenTappedAround()
         addKeyboardObserver()
@@ -138,6 +127,11 @@ class WriteVC: BaseVC {
     }
     
     // MARK: - Functions
+    private func setDelegate() {
+        writeModalVC.sendTitleDelegate = self
+        templateContentTV.buttonDelegate = self
+    }
+    
     func dataBind() {
         let output = templateContentVM.transform(
             input: TemplateContentViewModel.Input(input)
@@ -334,6 +328,14 @@ extension WriteVC: TemplateTitleDelegate {
     private func setTemplateContentTV(_ templateId: Int) {
         templateContentTV.templateId = templateId
         input.send(templateContentTV.templateId)
+    }
+}
+
+// MARK: - ActivateButtonDelegate
+extension WriteVC: ActivateButtonDelegate {
+    func isTitleEmpty(check: Bool) {
+        /// navigationBarView의 상태를 변경해준다.
+        navigationBarView.setupDoneButtonStatus(type: check)
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
1. 인스타그램 공유 화면 스크롤 가능하게 변경 (UIView -> tableView의 Header로 변경)
2. 처음 글 작성시 완료 버튼 비활성 > 제목 입력 후 활성으로 변경


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
1번은 완료 했고, 
2번은 제목이 있고, 내용도 모두 있어야 할 시에만 버튼이 활성화 되게끔 구현 더 해야합니다. 
현재는 제목의 유무만 판단하여 버튼 활성화를 시켜줍니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
1. 인스타 그램 공유 화면 스크롤
![Simulator Screen Recording - iPhone 13 mini - 2023-11-12 at 17 43 16](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/d204133d-10a7-4ced-b379-4155e6c8f58d)


## 🚨 관련 이슈
- Resolved: #95 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
