### PR TITLE
[Chore] 홈 고민 목록 조회 URI 수정사항 적용

### DIFF
--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -20,7 +20,7 @@ struct APIConstant {
     
     static let worryList = "/worry/list"
     static let worry = "/worry"
-    static let deadline = "/worrry/deadline"
+    static let deadline = "/worry/deadline"
     static let myAnswer = "/worry/myanswer"
     static let template = "/template"
     static let review = "/review"
@@ -28,4 +28,5 @@ struct APIConstant {
     static let refresh = "/auth/token/refresh"
     static let logout = "/auth/logout"
     static let appleLogin = "/auth/apple/login"
+    static let finalAnswer = "/worry/finalAnswer"
 }

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -23,15 +23,20 @@ extension HomeService: BaseTargetType {
     var path: String {
         switch self {
         case .homeGemList(let isSolved):
-            return APIConstant.worryList + "/\(isSolved)"
+            return APIConstant.worry + "/\(isSolved)/list"
+            
         case .worryDetail(let worryId), .deleteWorry(let worryId):
             return APIConstant.worry + "/\(worryId)"
+            
         case .updateDeadline:
-            return APIConstant.worry + "/deadline"
+            return APIConstant.deadline
+            
         case .editWorry:
             return APIConstant.worry
+            
         case .completeWorry:
-            return APIConstant.worry + "/finalAnswer"
+            return APIConstant.finalAnswer
+            
         case .patchReview:
             return APIConstant.review
         }
@@ -50,7 +55,9 @@ extension HomeService: BaseTargetType {
     
     var task: Task {
         switch self {
-        case .homeGemList, .worryDetail, .deleteWorry:
+        case .homeGemList:
+            return .requestParameters(parameters: ["page" : 1, "limit" : 12], encoding: URLEncoding.queryString)
+        case .worryDetail, .deleteWorry:
             return .requestPlain
         case .updateDeadline(let param):
             return .requestJSONEncodable(param)

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -109,7 +109,7 @@ class WriteVC: BaseVC {
     override func viewDidLoad() {
         super.viewDidLoad()
         /// 초기에 완료 상태 비활성화
-        navigationBarView.setupDoneButtonStatus(type: true)
+        navigationBarView.setupDoneButtonStatus(status: true)
         setNaviButtonAction()
         setLayout()
         setDelegate()
@@ -335,7 +335,7 @@ extension WriteVC: TemplateTitleDelegate {
 extension WriteVC: ActivateButtonDelegate {
     func isTitleEmpty(check: Bool) {
         /// navigationBarView의 상태를 변경해준다.
-        navigationBarView.setupDoneButtonStatus(type: check)
+        navigationBarView.setupDoneButtonStatus(status: check)
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
- 홈 화면 고민 목록을 조회시 기존에 모든 고민이 다 들어오는 API로 되어있어서 서버쪽에서 페이지네이션 적용하였고, 클라에서 기존처럼 12개로 받을 수 있도록 HomeService에서 `.requestParameters`를 이용해 page=1 limit=12로 쿼리를 추가하여 수정
- @oy6uns 가 이전 PR에서 함수 구현부에서 파라미터 변경 후 실행부에서 변경안된것 같이 수정

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- @oy6uns 고민 보관함도 페이지네이션을 적용할까 했으나 홈 화면에서는 일단 12개만 받으면 되기 때문에 크게 수정할게 없는데 고민 보관함의 경우 페이지네이션이 적용되면 사용자가 스크롤 함에 따라 쿼리를 변경해서 다음 데이터를 받고, 받고 하는 작업을 추가해야하기 때문에 우선은 보관함은 페이지네이션 적용없이 그대로 가기로 하였으니 참고해주세용

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #97 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
