### PR TITLE
[Feat] Interceptor를 이용한 토큰 갱신 로직 추가

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		E7AC122F2A51D54900FE504C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC122E2A51D54900FE504C /* CombineMoya */; };
 		E7AC12312A51D54900FE504C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC12302A51D54900FE504C /* Moya */; };
 		E7AC12342A51D56F00FE504C /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC12332A51D56F00FE504C /* SnapKit */; };
+		E7B091302B0DF6AA00F47BEB /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B0912F2B0DF6AA00F47BEB /* AuthInterceptor.swift */; };
 		E7B94D702ADDF9B8005D9FB8 /* MyPageTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B94D6F2ADDF9B8005D9FB8 /* MyPageTVC.swift */; };
 		E7B94D722ADDF9F3005D9FB8 /* MyPageTVHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B94D712ADDF9F3005D9FB8 /* MyPageTVHeaderView.swift */; };
 		E7B94D742ADE9A35005D9FB8 /* MyPaggeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B94D732ADE9A35005D9FB8 /* MyPaggeViewModel.swift */; };
@@ -229,6 +230,7 @@
 		E7A94CD22AB0910F00F231D0 /* KaeraAlertVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KaeraAlertVC.swift; sourceTree = "<group>"; };
 		E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralResponse.swift; sourceTree = "<group>"; };
 		E7AC12222A51D08300FE504C /* Temp_DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp_DataModel.swift; sourceTree = "<group>"; };
+		E7B0912F2B0DF6AA00F47BEB /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		E7B94D6F2ADDF9B8005D9FB8 /* MyPageTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTVC.swift; sourceTree = "<group>"; };
 		E7B94D712ADDF9F3005D9FB8 /* MyPageTVHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTVHeaderView.swift; sourceTree = "<group>"; };
 		E7B94D732ADE9A35005D9FB8 /* MyPaggeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPaggeViewModel.swift; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				E79AAC412A52F36500F3F439 /* NetworkConstant.swift */,
 				E79AAC422A52F36500F3F439 /* NetworkResult.swift */,
 				E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */,
+				E7B0912F2B0DF6AA00F47BEB /* AuthInterceptor.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -877,6 +880,7 @@
 				85831C322AF0F5F2008839A0 /* CompleteWorryModel.swift in Sources */,
 				850C55962ADB2AA00088ABBB /* WorryPatchManager.swift in Sources */,
 				85887DA02A612E1000F7FB21 /* TemplateInfoTVC.swift in Sources */,
+				E7B091302B0DF6AA00F47BEB /* AuthInterceptor.swift in Sources */,
 				E7BB4F3B2A5ED3610018312B /* HomeVC.swift in Sources */,
 				E7B94D722ADDF9F3005D9FB8 /* MyPageTVHeaderView.swift in Sources */,
 				E79AAC342A52F2C300F3F439 /* UIViewController+.swift in Sources */,

--- a/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
+++ b/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
@@ -11,7 +11,7 @@ import Moya
 final class ArchiveAPI {
     
     static let shared: ArchiveAPI = ArchiveAPI()
-    private let archiveProvider = MoyaProvider<ArchiveService>(plugins: [MoyaLoggingPlugin()])
+    private let archiveProvider = MoyaProvider<ArchiveService>(session: Session(interceptor: AuthInterceptor.shared),plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/AuthAPI.swift
+++ b/KAERA/KAERA/Network/APIs/AuthAPI.swift
@@ -11,7 +11,7 @@ import Moya
 final class AuthAPI {
     
     static let shared: AuthAPI = AuthAPI()
-    private let authProvider = MoyaProvider<AuthService>(plugins: [MoyaLoggingPlugin()])
+    private let authProvider = MoyaProvider<AuthService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -11,7 +11,8 @@ import Moya
 final class HomeAPI {
     
     static let shared: HomeAPI = HomeAPI()
-    private let homeProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggingPlugin()])
+
+    private let homeProvider = MoyaProvider<HomeService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -12,7 +12,7 @@ import Moya
 final class WriteAPI {
     
     static let shared: WriteAPI = WriteAPI()
-    private let writeProvider = MoyaProvider<WriteService>(plugins: [MoyaLoggingPlugin()])
+    private let writeProvider = MoyaProvider<WriteService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
     
     // tableView의 데이터들을 담는 싱글톤 클래스
     let contentInfo = WorryPostManager.shared

--- a/KAERA/KAERA/Network/Base/AuthInterceptor.swift
+++ b/KAERA/KAERA/Network/Base/AuthInterceptor.swift
@@ -1,0 +1,40 @@
+//
+//  AuthInterceptor.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/11/22.
+//
+
+import Foundation
+import Alamofire
+import Moya
+
+final class AuthInterceptor: RequestInterceptor {
+    
+    static let shared = AuthInterceptor()
+    
+    private init() {}
+
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        print("retry 진입")
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401, let pathComponents = request.request?.url?.pathComponents,
+              !pathComponents.contains("getNewToken")
+        else {
+            dump(error)
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        AuthAPI.shared.postRenewalRequest { res in
+            guard let res, let data = res.data else {
+                //TODO: 재갱신 실패시 Refresh Token까지 만료된 것이라 처리 필요
+                completion(.doNotRetryWithError(error))
+                return
+            }
+            let renewedAccessToken = data.accessToken
+            KeychainManager.save(key: .accessToken, value: renewedAccessToken)
+            completion(.retry)
+        }
+        
+    }
+}

--- a/KAERA/KAERA/Network/Services/ArchiveService.swift
+++ b/KAERA/KAERA/Network/Services/ArchiveService.swift
@@ -41,5 +41,9 @@ extension ArchiveService: BaseTargetType {
             return NetworkConstant.hasTokenHeader
         }
     }
+    
+    var validationType: ValidationType {
+         return .successCodes
+     }
 }
 

--- a/KAERA/KAERA/Network/Services/AuthService.swift
+++ b/KAERA/KAERA/Network/Services/AuthService.swift
@@ -66,4 +66,8 @@ extension AuthService: BaseTargetType {
             return NetworkConstant.hasTokenHeader
         }
     }
+    
+    var validationType: ValidationType {
+         return .successCodes
+     }
 }

--- a/KAERA/KAERA/Network/Services/HomeService.swift
+++ b/KAERA/KAERA/Network/Services/HomeService.swift
@@ -76,4 +76,8 @@ extension HomeService: BaseTargetType {
             return NetworkConstant.hasTokenHeader
         }
     }
+    
+    var validationType: ValidationType {
+         return .successCodes
+     }
 }

--- a/KAERA/KAERA/Network/Services/WriteService.swift
+++ b/KAERA/KAERA/Network/Services/WriteService.swift
@@ -57,5 +57,9 @@ extension WriteService: BaseTargetType {
             return NetworkConstant.hasTokenHeader
         }
     }
+    
+    var validationType: ValidationType {
+         return .successCodes
+     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
- Alamofire의 Interceptor를 이용해서 토큰만료 상태 코드 401일때 토큰을 갱신해주는 요청을 통해 토큰 갱신으로 다시 서버 요청 할 수 있도록함 
  - AuthInterceptor를 만들고, 각 API 파일 내 MoyaProvider에 AuthInterceptor를 추가해줬고
  - retry메서드가 정상적으로 작동할 수 있도록 각 service파일에서 ValidationType을 .successCodes로 설정해줬습니다.(기본 .none으로 설정 되어있으면 어떤 상태 코드던지 따로 retry를 수행하지 않으므로 200번대를 의미하는 .successCodes로 validationType을 설정하고 

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 우리가 글을 작성하고, 고민 목록을 조회하고 하는 대부분의 요청이 헤더의 엑세스 토큰을 넣어 요청을 하는데 엑세스 토큰의 유효시간이 보안상 2시간 이내로 짧게 설정이 되어있기 때문에 토큰이 만료되기 쉽습니다. 
- 그래서 만료 주기가 긴 refreshToken을 이용해서 accessToken을 갱신해 주는데 현재 앱 초반에 SplashVC에서 갱신을 해주고 있는데 앱 진입 이후 다른 페이지에서 엑세스 토큰이 만료 될 수 있기 때문에 (예를 들어 고민을 다 쓰고 완료를 누르는데 토큰이 만료되어 요청에 실패함)
이는 유저에게 큰 불편을 줄 수 있기 때문에 유저가 토큰 만료 때문에 동작을 제대로 못 쓰는 일이 없도록 서버 요청시 토큰 만료 코드 (401)이 뜨면 Interceptor라는 것을 통해 뒷단에서 알아서 토큰을 갱신해서 갱신된 토큰으로 재 요청하도록 해주었습니다.

- 세진쓰의 [모야 인터셉터 적용 글]( https://lsj8706.tistory.com/21)과 https://eeyatho.tistory.com/256 요 글을 보고 Interceptor를 추가해 갱신 로직을 추가했습니다.

- Interceptor는 Moya가 아닌 Alamofire에서 구현되어있는 것이지만 아래 사진에서 보다시피 Moya는 Alamofire를 추상화 한 것으로 Alamofire에 있는 Interceptor를 쓸 수 있습니다.
Interceptor는 서버로 요청 전에 adapt 메서드를 실행할 수 있고, 응답을 받아 처리 전에 retry 메서드를 수행할 수 있습니다.
- adapt에서 헤더로 토큰 넘겨주는 동작 등을 추가해서 쓸 수 있으나 기존의 헤더에 토큰을 넣는 로직은 Service에서 이미 수행하고 있으므로 adapt부분은 구현하지 않고, 
- retry부분만 구현하여 401 토큰 만료 코드가 떴을 때 토큰 갱신 요청을 해서 갱신된 엑세스 토큰을 키체인에 저장후 다시 원래 요청을 수행할 수 있도록 했습니다.

![image](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/822e4627-502b-432d-98cf-fa99a3ceaa02)


## 🚨 관련 이슈
- Resolved: #102 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
