### PR TITLE
[Feat] 앱 처음 실행시 키체인 데이터 초기화 로직 추가

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		E74968D62A74B84100C3C0CF /* WorryDetailReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */; };
 		E74969302A7B2DF000C3C0CF /* WorryDecisionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */; };
 		E74969342A80AE2100C3C0CF /* WorryQuoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */; };
+		E76C7AD52B1490D4008BE56B /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76C7AD42B1490D4008BE56B /* UserDefaults+.swift */; };
 		E772E70D2AF9AE650098E091 /* HomeGemStoneCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */; };
 		E78B648B2AF85FA00046215D /* WorryReviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B648A2AF85FA00046215D /* WorryReviewModel.swift */; };
 		E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */; };
@@ -199,6 +200,7 @@
 		E74968D52A74B84100C3C0CF /* WorryDetailReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDetailReviewView.swift; sourceTree = "<group>"; };
 		E749692F2A7B2DF000C3C0CF /* WorryDecisionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDecisionVC.swift; sourceTree = "<group>"; };
 		E74969332A80AE2100C3C0CF /* WorryQuoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryQuoteView.swift; sourceTree = "<group>"; };
+		E76C7AD42B1490D4008BE56B /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGemStoneCount.swift; sourceTree = "<group>"; };
 		E78B648A2AF85FA00046215D /* WorryReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryReviewModel.swift; sourceTree = "<group>"; };
 		E79AAC1E2A52F16300F3F439 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				E79AAC252A52F2C200F3F439 /* UITextField+.swift */,
 				E79AAC232A52F2C200F3F439 /* UIView+.swift */,
 				E79AAC262A52F2C200F3F439 /* UIViewController+.swift */,
+				E76C7AD42B1490D4008BE56B /* UserDefaults+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -890,6 +893,7 @@
 				E79AAC1F2A52F16300F3F439 /* ImageCacheManager.swift in Sources */,
 				E79AAC472A52F36500F3F439 /* NetworkResult.swift in Sources */,
 				E73CA3DF2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift in Sources */,
+				E76C7AD52B1490D4008BE56B /* UserDefaults+.swift in Sources */,
 				E70764692ABFF68800627AA7 /* AuthAPI.swift in Sources */,
 				85A8492B2A87A13B009F1468 /* TemplateContentViewModel.swift in Sources */,
 				E7A94CC42AA484E300F231D0 /* SignInVC.swift in Sources */,

--- a/KAERA/KAERA/Application/AppDelegate.swift
+++ b/KAERA/KAERA/Application/AppDelegate.swift
@@ -11,11 +11,12 @@ import Firebase
 import UserNotifications
 
 
-
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        /// 앱 첫 실행이면 KeyChain Data 삭제
+        removeKeychainAtFirstLaunch()
         
         KakaoSDK.initSDK(appKey: Environment.kakaoAppKey)
         // Firebase SDK 초기화
@@ -35,6 +36,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Messaging.messaging().isAutoInitEnabled = true
         
         return true
+    }
+    
+    private func removeKeychainAtFirstLaunch() {
+        guard UserDefaults.isFirstLaunch() else {
+            return
+        }
+        KeychainManager.clearAllUserInfo()
     }
     
     /// 푸시 권한 요청

--- a/KAERA/KAERA/Global/Extensions/UserDefaults+.swift
+++ b/KAERA/KAERA/Global/Extensions/UserDefaults+.swift
@@ -1,0 +1,19 @@
+//
+//  UserDefaults+.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/11/27.
+//
+
+import Foundation
+
+extension UserDefaults {
+    public static func isFirstLaunch() -> Bool {
+        let hasBeenLaunchedBeforeFlag = "hasBeenLaunchedBeforeFlag"
+        let isFirstLaunch = !UserDefaults.standard.bool(forKey: hasBeenLaunchedBeforeFlag)
+        if isFirstLaunch {
+            UserDefaults.standard.set(true, forKey: hasBeenLaunchedBeforeFlag)
+        }
+        return isFirstLaunch
+    }
+}


### PR DESCRIPTION
## 💪 작업한 내용
- [김종권님의 블로그 글](https://ios-development.tistory.com/262) 를 참고하여 
- 앱을 처음 실행했을 때 UserDefaults 익스텐션으로 isFirstLaunch 메서드를 추가해서 첫 실행시에만 true가 리턴되도록 하고 이를 AppDelegate에서 앱 런치시 실행되게 하여 리턴값이 true일때 KeyChainClearUserInfo를 통해 키체인에 저장된 데이터들을 초기화시키도록함


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 앱을 삭제하고 다시 실행했을 때 기존의 키체인 데이터에 저장된 토큰으로 인해 로그인 페이지를 넘어갈 수 있어서 해당 로직을 추가하게 되었습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #109 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
