### PR TITLE
[FIX] 고민작성 창 엠티뷰, 모달 띄우기 로직 추가

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		E72D6AE82B1C234000CF8B01 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = E72D6AE72B1C234000CF8B01 /* Lottie */; };
 		E72D6AEB2B1C255F00CF8B01 /* kaera_loading.json in Resources */ = {isa = PBXBuildFile; fileRef = E72D6AEA2B1C255F00CF8B01 /* kaera_loading.json */; };
 		E72D6AF32B1C907800CF8B01 /* EditWorryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D6AF22B1C907800CF8B01 /* EditWorryResponseModel.swift */; };
+		E72D6AF62B21E1A500CF8B01 /* WriteEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D6AF52B21E1A500CF8B01 /* WriteEmptyView.swift */; };
 		E73CA3DA2A69300F00BAC9D6 /* HomePublisherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */; };
 		E73CA3DC2A693C9D00BAC9D6 /* GemStoneEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */; };
 		E73CA3DF2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */; };
@@ -196,6 +197,7 @@
 		E71FC2432ADC01B6001DD27D /* MyPageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageVC.swift; sourceTree = "<group>"; };
 		E72D6AEA2B1C255F00CF8B01 /* kaera_loading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = kaera_loading.json; sourceTree = "<group>"; };
 		E72D6AF22B1C907800CF8B01 /* EditWorryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWorryResponseModel.swift; sourceTree = "<group>"; };
+		E72D6AF52B21E1A500CF8B01 /* WriteEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteEmptyView.swift; sourceTree = "<group>"; };
 		E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePublisherModel.swift; sourceTree = "<group>"; };
 		E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GemStoneEmptyView.swift; sourceTree = "<group>"; };
 		E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailVC.swift; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				85EBC7F42A5AD94100B9E891 /* WriteVC.swift */,
 				85887D8F2A5EFA2C00F7FB21 /* WritePickerVC.swift */,
 				85887D802A5C428500F7FB21 /* WriteModal */,
+				E72D6AF52B21E1A500CF8B01 /* WriteEmptyView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -932,6 +935,7 @@
 				E79AAC332A52F2C300F3F439 /* UITextField+.swift in Sources */,
 				E79AAC322A52F2C300F3F439 /* UIColor+.swift in Sources */,
 				E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */,
+				E72D6AF62B21E1A500CF8B01 /* WriteEmptyView.swift in Sources */,
 				E73CA3E22A6A688A00BAC9D6 /* CustomNavigationBarView.swift in Sources */,
 				85887D972A60430600F7FB21 /* ArchiveModalCVC.swift in Sources */,
 				E79AAC372A52F2C300F3F439 /* CALayer+.swift in Sources */,

--- a/KAERA/KAERA/Scenes/KaeraTabbarController.swift
+++ b/KAERA/KAERA/Scenes/KaeraTabbarController.swift
@@ -88,7 +88,9 @@ extension KaeraTabbarController: UITabBarControllerDelegate {
                 let writeVC = WriteVC(type: .post)
                 writeVC.modalPresentationStyle = .fullScreen
                 writeVC.modalTransitionStyle = .coverVertical
-                self.present(writeVC, animated: true, completion: nil)
+                self.present(writeVC, animated: true) {
+                    writeVC.modalTemplateSelectVC()
+                }
             }
             return false // 탭 변경을 막음
         }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteEmptyView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteEmptyView.swift
@@ -1,0 +1,64 @@
+//
+//  WriteEmptyView.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/12/07.
+//
+
+import UIKit
+import SnapKit
+
+final class WriteEmptyView: UIView {
+
+    private let baseImage = UIImageView().then {
+        $0.image = UIImage(named: "gem_no_template")
+        $0.contentMode = .scaleToFill
+        $0.backgroundColor = .clear
+    }
+    
+    private let introTitle = UILabel().then {
+        $0.text = "선택된 템플릿이 없어요!"
+        $0.textColor = .kWhite
+        $0.font = .kH3B18
+    }
+    
+    private let introDetail = UILabel().then {
+        $0.text = "상단에서 템플릿을 골라볼까요?"
+        $0.textColor = .kGray4
+        $0.font = .kSb1R12
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - UI
+extension WriteEmptyView {
+    private func setLayout() {
+        self.addSubviews([baseImage, introTitle, introDetail])
+        
+        baseImage.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(200)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(120.adjustedW)
+            $0.height.equalTo(95.adjustedW)
+        }
+        
+        introTitle.snp.makeConstraints {
+            $0.top.equalTo(baseImage.snp.bottom).offset(32)
+            $0.centerX.equalToSuperview()
+        }
+        
+        introDetail.snp.makeConstraints {
+            $0.top.equalTo(introTitle.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -55,33 +55,16 @@ final class WriteVC: BaseVC {
         $0.backgroundColor = .kGray2
     }
     
-    private let bottomDividingLine = UIView().then {
-        $0.backgroundColor = .kGray3
-    }
-    
     private let worryContentLabel = UILabel().then {
         $0.text = "고민 내용 작성하기"
         $0.textColor = .kWhite
         $0.font = .kB2R16
     }
     
-    private let baseImage = UIImageView().then {
-        $0.image = UIImage(named: "gem_no_template")
-        $0.contentMode = .scaleToFill
-        $0.backgroundColor = .clear
-    }
+    private let writeEmptyView = WriteEmptyView()
     
-    private let introTitle = UILabel().then {
-        $0.text = "선택된 템플릿이 없어요!"
-        $0.textColor = .kWhite
-        $0.font = .kH3B18
-    }
+    private var isTemplateContentTVAdded = false
     
-    private let introDetail = UILabel().then {
-        $0.text = "상단에서 템플릿을 골라볼까요?"
-        $0.textColor = .kGray4
-        $0.font = .kSb1R12
-    }
     private var writeType: WriteType = .post
     
     private var tempAnswers: [String] = []
@@ -277,12 +260,12 @@ final class WriteVC: BaseVC {
         }
     }
     
-    private func modalTemplateSelectVC() {
+    func modalTemplateSelectVC() {
         self.writeModalVC.modalPresentationStyle = .pageSheet
         
         if let sheet = self.writeModalVC.sheetPresentationController {
             /// 지원할 크기 지정(.medium(), .large())
-            sheet.detents = [.medium()]
+            sheet.detents = [.medium(), .large()]
             
             /// 시트 상단에 그래버 표시 (기본 값은 false)
             sheet.prefersGrabberVisible = true
@@ -328,6 +311,18 @@ final class WriteVC: BaseVC {
 // MARK: - TemplateIdDelegate
 extension WriteVC: TemplateIdDelegate {
     func templateReload(templateId: Int) {
+        if !isTemplateContentTVAdded {
+            view.addSubview(templateContentTV)
+
+            templateContentTV.snp.makeConstraints {
+                $0.top.equalTo(self.dividingLine.snp.bottom)
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalToSuperview()
+            }
+            
+            isTemplateContentTVAdded = true
+        }
+        
         startLoadingAnimation()
         input.send(templateId)
         // 처음 고민작성시 템플릿을 선택했을때 writeType을 바꿔줌
@@ -417,15 +412,7 @@ extension WriteVC {
         view.backgroundColor = .kGray1
         view.addSubviews([navigationBarView, templateBtn])
         templateBtn.addSubviews([templateTitle, templateInfo, dropdownImg])
-        view.addSubviews([baseImage, introTitle, introDetail])
-        view.addSubviews([dividingLine])
-        view.addSubview(templateContentTV)
-        
-        templateContentTV.snp.makeConstraints {
-            $0.top.equalTo(self.dividingLine.snp.bottom)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
-        }
+        view.addSubview(dividingLine)
 
         navigationBarView.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
@@ -461,21 +448,24 @@ extension WriteVC {
             $0.height.equalTo(12)
         }
         
-        baseImage.snp.makeConstraints {
-            $0.top.equalTo(dividingLine.snp.bottom).offset(200.adjustedW)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(120.adjustedW)
-            $0.height.equalTo(95.adjustedW)
-        }
-        
-        introTitle.snp.makeConstraints {
-            $0.top.equalTo(baseImage.snp.bottom).offset(32)
-            $0.centerX.equalToSuperview()
-        }
-        
-        introDetail.snp.makeConstraints {
-            $0.top.equalTo(introTitle.snp.bottom).offset(16)
-            $0.centerX.equalToSuperview()
+        if writeType == .patch {
+            view.addSubview(templateContentTV)
+            
+            templateContentTV.snp.makeConstraints {
+                $0.top.equalTo(self.dividingLine.snp.bottom)
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalToSuperview()
+            }
+            
+            self.isTemplateContentTVAdded = true
+        } else {
+            view.addSubview(writeEmptyView)
+            
+            writeEmptyView.snp.makeConstraints {
+                $0.top.equalTo(dividingLine)
+                $0.width.equalToSuperview()
+                $0.bottom.equalToSuperview()
+            }
         }
     }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- WriteVC 내부에 따로 정의되어 있던 엠티뷰 관련 컴포넌트들을 빼서 WriteEmptyView라는 UIView 클래스를 생성
- 기존에 테이블뷰 위에 엠티뷰를 올려도, 테이블뷰의 헤더뷰가 늦게 로드되어 테이블 뷰는 엠티뷰 뒤어 있지만 헤더뷰는 엠티뷰 위에 올라가는 문제가 있었음.
- 엠티뷰는 고민 수정이 아닌 작성시에, 템플릿 선택 전에만 보이는 뷰로 고민 작성시에만 empty뷰를 추가하고, 수정시에는 바로 테이블뷰를 추가함
- 고민 작성시 테이블 뷰는 writeModalVC에서 템플릿이 선택되었을때 실행되는 writeVC의 templateReload 메서드에서 isTemplateContentTVAdded 플래그를 사용해 처음에 테이블 뷰가 추가 될 수 있도록함.
- 고민 작성 present시 writeModal을 바로 띄울 수 있도록 탭바에서 writeVC 인스턴의 모달을 띄우는 메서드 modalTempalteSelectVC를 실행

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-07 at 21 48 09](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/cabee28a-6b90-431f-8528-e1aaaef8fa12)

## 🚨 관련 이슈
- Resolved: #118 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
