### PR TITLE
[Feat] 서비스 로그아웃 및 회원탈퇴 API 연결

### DIFF
--- a/KAERA/KAERA/Network/APIs/AuthAPI.swift
+++ b/KAERA/KAERA/Network/APIs/AuthAPI.swift
@@ -17,8 +17,9 @@ final class AuthAPI {
     
     public private(set) var kakaoLoginResponse: GeneralResponse<SignInModel>?
     public private(set) var renewalResponse: GeneralResponse<RenewalTokenModel>?
-    public private(set) var kakaoLogoutResponse: EmptyResponse?
+    public private(set) var serviceLogoutResponse: EmptyResponse?
     public private(set) var appleSignInResponse: GeneralResponse<SignInModel>?
+    public private(set) var deleteAccountResponse: EmptyResponse?
     
     
     func postKakaoLogin(token: String, completion: @escaping (GeneralResponse<SignInModel>?) -> ()) {
@@ -64,13 +65,13 @@ final class AuthAPI {
         }
     }
     
-    func postKakaoLogout(completion: @escaping (Int?) -> ()) {
-        authProvider.request(.kakaoLogout) { [weak self] response in
+    func postLogout(completion: @escaping (Int?) -> ()) {
+        authProvider.request(.serviceLogout) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
-                    self?.kakaoLogoutResponse = try result.map(EmptyResponse?.self)
-                    guard let res = self?.kakaoLogoutResponse else { return }
+                    self?.serviceLogoutResponse = try result.map(EmptyResponse?.self)
+                    guard let res = self?.serviceLogoutResponse else { return }
                     switch res.status {
                     case 200..<300:
                         completion(res.status)
@@ -96,6 +97,30 @@ final class AuthAPI {
                     self?.appleSignInResponse = try result.map(GeneralResponse<SignInModel>?.self)
                     guard let res = self?.appleSignInResponse else { return }
                     completion(res)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    completion(nil)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func deleteAccount(completion: @escaping (Int?) -> ()) {
+        authProvider.request(.deleteAccount) { [weak self] response in
+            switch response {
+            case .success(let result):
+                do {
+                    self?.deleteAccountResponse = try result.map(EmptyResponse?.self)
+                    guard let res = self?.deleteAccountResponse else { return }
+                    switch res.status {
+                    case 200..<300:
+                        completion(res.status)
+                    default:
+                        completion(nil)
+                    }
                 } catch(let err) {
                     print(err.localizedDescription)
                     completion(nil)

--- a/KAERA/KAERA/Network/Base/APIConstant.swift
+++ b/KAERA/KAERA/Network/Base/APIConstant.swift
@@ -29,4 +29,5 @@ struct APIConstant {
     static let logout = "/auth/logout"
     static let appleLogin = "/auth/apple/login"
     static let finalAnswer = "/worry/finalAnswer"
+    static let deleteAccount = "/auth/unregister"
 }

--- a/KAERA/KAERA/Network/Services/AuthService.swift
+++ b/KAERA/KAERA/Network/Services/AuthService.swift
@@ -10,9 +10,10 @@ import Moya
 
 enum AuthService {
     case kakaoLogin(token: String)
-    case kakaoLogout
+    case serviceLogout
     case renewelToken
     case appleLogin(body: AppleSignInRequestBody)
+    case deleteAccount
 }
 
 extension AuthService: BaseTargetType {
@@ -23,17 +24,21 @@ extension AuthService: BaseTargetType {
             return APIConstant.kakaoLogin
         case .renewelToken:
             return APIConstant.refresh
-        case .kakaoLogout:
+        case .serviceLogout:
             return APIConstant.logout
         case .appleLogin:
             return APIConstant.appleLogin
+        case .deleteAccount:
+            return APIConstant.deleteAccount
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .kakaoLogin, .renewelToken, .kakaoLogout, .appleLogin:
+        case .kakaoLogin, .renewelToken, .serviceLogout, .appleLogin:
             return .post
+        case .deleteAccount:
+            return .delete
         }
     }
     
@@ -50,11 +55,14 @@ extension AuthService: BaseTargetType {
             let requestBody = RenewalRequestBody(accessToken: accessToken, refreshToken: refreshToken)
             return .requestJSONEncodable(requestBody)
             
-        case .kakaoLogout:
+        case .serviceLogout:
             return .requestPlain
         
 		case .appleLogin(let body):
             return .requestJSONEncodable(body)
+            
+        case .deleteAccount:
+            return .requestPlain
         }
     }
     
@@ -62,7 +70,7 @@ extension AuthService: BaseTargetType {
         switch self {
         case .kakaoLogin, .renewelToken, .appleLogin:
             return NetworkConstant.noTokenHeader
-        case .kakaoLogout:
+        case .serviceLogout, .deleteAccount:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/KAERA/KAERA/Scenes/Auth/Model/MyPageDataType.swift
+++ b/KAERA/KAERA/Scenes/Auth/Model/MyPageDataType.swift
@@ -16,7 +16,7 @@ enum MyPageInputType {
 enum MyPageOutputType {
     case data(data: [MyPageTVCModel])
     case push(hasChanged: Bool)
-    case accountAction
+    case accountAction(type: AccountActionType)
     case networkFail
 }
 

--- a/KAERA/KAERA/Scenes/Auth/View/MyPageVC.swift
+++ b/KAERA/KAERA/Scenes/Auth/View/MyPageVC.swift
@@ -109,12 +109,16 @@ final class MyPageVC: BaseVC {
             if hasChanged {
                 myPageTV.reloadData()
             }
-        case .accountAction:
+        case .accountAction(let type):
             if let alertVC = self.presentedViewController {
                 alertVC.dismiss(animated: true) {
                     if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-                        // window의 rootViewController 설정
-                        sceneDelegate.window?.rootViewController = SplashVC()
+                        switch type {
+                        case .signOut:
+                            sceneDelegate.window?.rootViewController = SignInVC()
+                        case .delete:
+                            sceneDelegate.window?.rootViewController = SplashVC()
+                        }
                     }
 
                 }

--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -114,9 +114,13 @@ extension SignInViewModel: ASAuthorizationControllerDelegate {
             
             let user = appleIDCredential.user
             let fullName = appleIDCredential.fullName
+            var userName = ""
             
-            /// 이름을 못받을 경우 "해라"로 기입 될 수 있게 수정
-            let userName = (fullName?.familyName ?? "") + (fullName?.givenName ?? "해라")
+            if let familyName = fullName?.familyName, let givenName = fullName?.givenName {
+                userName = familyName + givenName
+            }else {
+                userName = KeychainManager.load(key: .userName) ?? "해라"
+            }
             
             if let identityToken = appleIDCredential.identityToken,
                let tokenString = String(data: identityToken, encoding: .utf8) {


### PR DESCRIPTION
## 💪 작업한 내용
- 기존의 kakaoLogout으로 작성했던 API 관련 코드를 애플로그인 로그아웃 겸용을 쓰기 위해 serviceLogout이라는 이름으로 수정
  - 대신 카카오 로그인의 경우를 구분하여 로그아웃 시 캐라 로그아웃 API를 호출하고 카카오 로그아웃 API를 따로 호출해주었음
  - 로그아웃시에는 키체인의 엑세스 토큰만 삭제하고, SignInVC로 이동
- 회원탈퇴 API를 추가하였는데 이것도 로그아웃처럼, 애플, 카카오 겸용으로 사용함
  - 이것도 카카오 로그인의 경우를 구분해, 카카오 로그인 연결 끊기를 추가로 호출함
  - 회원탈퇴시 키체인의 `유저이름`을 제외한 모든 데이터를 제외한 모든 데이터를 삭제하고, SplashVC로 이동

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 애플로그인은 처음에만 유저정보를 받을 수 있고 카카오처럼 코드로 로그인 연결을 끊을 수 없기에 다시 애플로그인했을때 유저 정보를 못 받는 문제가 있습니다. 
- 그래서 키체인에다가 저장해두고 애플로그인시 유저정보를 못받을때 키체인의 데이터를 로드해서 가져올 수 있도록 하였습니다.
- 회원탈퇴시에도 유저 이름만 일부러 안지워 다시 애플로그인시에도 키체인의 유저 이름 데이터를 가져올 수 있도록 하였습니다. 
- 그러나 애플로그인 유저가 앱을 지우고 다시 실행시 모든 키체인 데이터를 지우도록 하여 유저이름을 아예 가져올 수 없는 문제가 발생합니다. 이때는 이름을 "해라"로 저장하도록 했습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
- 카카오로그인 회원탈퇴 후 다시 로그인할때 재 가입이 되는것을 확인했는데 찍진 못했네요ㅠ

## 🚨 관련 이슈
- Resolved: #115 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
