### PR TITLE
[Fix] 템플릿 정보 작성하러가기 시 template 조회 아이디 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoTVC.swift
@@ -89,9 +89,8 @@ class TemplateInfoTVC: UITableViewCell {
     // MARK: - Functions
     private func pressBtn() {
         writingBtn.press {
-            /// indexPath[1] : 값의 row data를 담고 있음.
-            let templateId = self.indexPath?[1] ?? 0
-            self.delegate?.didPressWritingButton(templateId: templateId)
+            let indexRow = self.indexPath?[1] ?? 0
+            self.delegate?.didPressWritingButton(templateId: indexRow + 1)
         }
     }
     
@@ -103,7 +102,6 @@ class TemplateInfoTVC: UITableViewCell {
     
     @objc
     func cellTap(_ gesture: UITapGestureRecognizer) {
-        print("CellTouched")
         NotificationCenter.default.post(
                 name: NSNotification.Name("CellTouched"),
                 object: nil,

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -45,8 +45,6 @@ class TemplateInfoVC: BaseVC, TemplateInfoTVCDelegate {
     
     private let writeModalVC = WriteModalVC()
     
-    private var templateId: Int = 1
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         dataBind()
@@ -96,7 +94,6 @@ class TemplateInfoVC: BaseVC, TemplateInfoTVCDelegate {
             /// Cell의 상태를 담고 있는 Bool 배열에서 click된 cell의 상태를 변경 (true <-> false)
             expandedCells[indexPath.row] = !expandedCells[indexPath.row]
             templateInfoTV.reloadRows(at: [indexPath], with: .automatic)
-            print(expandedCells)
         }
     }
     
@@ -126,9 +123,6 @@ class TemplateInfoVC: BaseVC, TemplateInfoTVCDelegate {
         let writeVC = WriteVC(type: .postDifferentTemplate)
         writeVC.modalPresentationStyle = .fullScreen
         self.present(writeVC, animated: true, completion: nil)
-        writeVC.dataBind()
-        self.templateId = templateId
-        writeVC.input.send(templateId)
         writeVC.templateReload(templateId: templateId)
     }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- TemplateInfoTVC의 작성하러가기 버튼 클릭시 선택된 셀의 인덱스 값을 넘겨줘서 TemplateInfoVC에서 writeVC로 연결이 되도록했는데 이때 인덱스값과 실제 템플릿 아이디가 맞지 않아 오류가 나서 (0번 인덱스 -> 0번 템플릿 조회 오류) 템플릿 아이디 = 인덱스 + 1로 넘겨주도록 수정
- 기타 불필요한 코드 및 프린트문 삭제

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #122 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
