### PR TITLE
[Fix] 고민수정시 내용이 텍스트의 높이를 반영하지 못하는 문제 

### DIFF
--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -113,6 +113,7 @@ extension TemplateContentTV : UITableViewDataSource
         /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
         cell.delegate = self
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], answer: answers[indexPath.row], index: indexPath.row)
+        cell.adjustTextViewHeight()
 
         return cell
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -88,6 +88,17 @@ class TemplateContentTVC: UITableViewCell {
             textView.textColor = .kWhite
         }
     }
+    
+    func adjustTextViewHeight() {
+        let newSize = CGSize(width: textView.frame.size.width, height: .infinity)
+
+        let newSizeThatFits = textView.sizeThatFits(newSize)
+        
+        textView.snp.updateConstraints {
+            $0.height.equalTo(newSizeThatFits.height)
+        }
+        
+    }
 }
 
 extension TemplateContentTVC: UITextViewDelegate {


### PR DESCRIPTION

## 💪 작업한 내용
- 고민 수정시 고민 내용을 보여주는 textView의 크기가 사전에 작성된 텍스트의 길이를 반영하지 못하는 문제가 있어서
- adjustTextViewHeight이라는 메서드를 추가로 만들어 textView의 무한대의 크기로 새로운 CGSize를 만들고 sizeThatFits로 textView의 사이즈를 다시 만들고
- 스냅킷의 updateConstraint를 통해 높이를 다시 잡아 주었고
- templateConentTV에서 dataBind 후 adjustTextViewHeight을 실행시킴


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #119 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
