### PR TITLE
[Fix] 데드라인 관련 로직 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -62,7 +62,6 @@ final class HomeWorryDetailVC: BaseVC {
     private var worryTitle = ""
     private var templateId = 1
     private var worryId = 1
-    private var dDay = ""
     private var period = ""
     private var pageType: PageType = .digging
     
@@ -234,17 +233,8 @@ final class HomeWorryDetailVC: BaseVC {
         
         switch pageType {
         case .digging:
-            /// dDay가 -888인 경우 데드라인 미 지정한 것
-            if worryDetail.dDay < -800 || worryDetail.dDay > 800 {
-                dDay = "-∞"
-            } else if worryDetail.dDay > 0 {
-                dDay = "-\(worryDetail.dDay)"
-            } else if worryDetail.dDay < 0 {
-                dDay = "\(worryDetail.dDay)"
-            } else if worryDetail.dDay == 0 {
-                dDay = "day"
-            }
-            navigationBarView.setTitleText(text: "고민캐기 D\(dDay)")
+            updateDeadline(deadline: worryDetail.dDay)
+
         case .dug:
             if let finalAnswer = worryDetail.finalAnswer {
                 self.finalAnswer = finalAnswer
@@ -268,14 +258,15 @@ final class HomeWorryDetailVC: BaseVC {
     
     /// 전달 받은 수정된 데드라인 일자로 navigationBar Title 변경
     func updateDeadline(deadline: Int) {
+        var dDay = ""
         if deadline < -800 || deadline > 800 {
             dDay = "-∞"
-        } else if deadline > 0 {
-            dDay = "-\(deadline)"
         } else if deadline < 0 {
             dDay = "\(deadline)"
+        } else if deadline > 0 {
+            dDay = "+\(deadline)"
         } else if deadline == 0 {
-            dDay = "day"
+            dDay = "-day"
         }
         navigationBarView.setTitleText(text: "고민캐기 D\(dDay)")
     }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -29,7 +29,7 @@ class TemplateContentTVC: UITableViewCell {
         $0.backgroundColor = .clear
     }
     
-    private let textViewConstant: CGFloat = 111.adjustedH
+    private let textViewHeightConstant: CGFloat = 111.adjustedH
     
     private var placeHolder: String = ""
             
@@ -93,11 +93,12 @@ class TemplateContentTVC: UITableViewCell {
         let newSize = CGSize(width: textView.frame.size.width, height: .infinity)
 
         let newSizeThatFits = textView.sizeThatFits(newSize)
-        
-        textView.snp.updateConstraints {
-            $0.height.equalTo(newSizeThatFits.height)
+
+        if newSizeThatFits.height > textViewHeightConstant {
+            textView.snp.updateConstraints {
+                $0.height.equalTo(newSizeThatFits.height)
+            }
         }
-        
     }
 }
 
@@ -112,11 +113,11 @@ extension TemplateContentTVC: UITextViewDelegate {
         /// 높이가 111보다 커지면 아래의 코드 실행, 넘지 않으면 고정 높이 반영
         textView.constraints.forEach { (constraint) in
             if constraint.firstAttribute == .height {
-                if estimatedSize.height > textViewConstant {
+                if estimatedSize.height > textViewHeightConstant {
                     constraint.constant = estimatedSize.height
                 }
                 else {
-                    constraint.constant = textViewConstant
+                    constraint.constant = textViewHeightConstant
                 }
             }
         }

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -21,6 +21,8 @@ class WritePickerVC: BaseVC {
     
     let pickerViewLayout = UIView().then {
         $0.backgroundColor = .kGray1
+        $0.layer.cornerRadius = 8
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
     }
     
     let datePickerView = UIPickerView().then {
@@ -48,19 +50,7 @@ class WritePickerVC: BaseVC {
         $0.font = .kH2R20
         $0.textColor = .kWhite
     }
-    
-    private let upperCover = UIView().then {
-        $0.backgroundColor = .kGray1
-        $0.layer.cornerRadius = 8
-        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-    }
-    
-    private let lowerCover = UIView().then {
-        $0.backgroundColor = .kGray1
-        $0.layer.cornerRadius = 8
-        $0.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-    }
-    
+
     let completeWritingBtn = UIButton().then {
         $0.backgroundColor = .kGray5
         $0.titleLabel?.font = .kB2R16
@@ -216,13 +206,18 @@ extension WritePickerVC {
         view.backgroundColor = .black.withAlphaComponent(0.5)
         view.addSubview(pickerViewLayout)
         
-        pickerViewLayout.addSubviews([datePickerView, upperCover, pickerViewTitle, lowerCover, completeWritingBtn, noDeadlineBtn])
+        pickerViewLayout.addSubviews([pickerViewTitle, datePickerView, completeWritingBtn, noDeadlineBtn])
         
         pickerViewLayout.snp.makeConstraints {
             $0.width.equalTo(358.adjustedW)
-            $0.height.equalTo(360.adjustedW)
+            $0.height.equalTo(448.adjustedH)
             $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview()
+        }
+        
+        pickerViewTitle.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(54.adjustedW)
+            $0.centerX.equalToSuperview()
         }
         
         /// datepickerView 관련 Component
@@ -232,7 +227,7 @@ extension WritePickerVC {
             $0.width.equalTo(358.adjustedW)
             $0.height.equalTo(136.adjustedW)
             $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview()
+            $0.top.equalTo(pickerViewTitle.snp.bottom).offset(50.adjustedH)
         }
         
         firstLabel.snp.makeConstraints {
@@ -244,39 +239,19 @@ extension WritePickerVC {
             $0.trailing.equalToSuperview().offset(-32.adjustedW)
             $0.centerY.equalToSuperview()
         }
-        
-        /// pickerVC 관련 Component
-        upperCover.snp.makeConstraints {
-            $0.leading.equalTo(datePickerView.snp.leading)
-            $0.trailing.equalTo(datePickerView.snp.trailing)
-            $0.bottom.equalTo(datePickerView.snp.top)
-            $0.height.equalTo(120)
-        }
-        
-        pickerViewTitle.snp.makeConstraints {
-            $0.top.equalTo(upperCover.snp.top).offset(54.adjustedW)
-            $0.centerX.equalToSuperview()
-        }
-        
-        lowerCover.snp.makeConstraints {
-            $0.leading.equalTo(datePickerView.snp.leading)
-            $0.trailing.equalTo(datePickerView.snp.trailing)
-            $0.top.equalTo(datePickerView.snp.bottom)
-            $0.height.equalTo(192)
-        }
-        
+
         completeWritingBtn.snp.makeConstraints {
             $0.width.equalTo(326.adjustedW)
             $0.height.equalTo(52.adjustedW)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(lowerCover.snp.bottom).offset(-90.adjustedW)
+            $0.top.equalTo(datePickerView.snp.bottom).offset(50.adjustedH)
         }
         
         noDeadlineBtn.snp.makeConstraints {
             $0.width.equalTo(113.adjustedW)
             $0.height.equalTo(21.adjustedW)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(lowerCover.snp.bottom).offset(-56.adjustedW)
+            $0.top.equalTo(completeWritingBtn.snp.bottom).offset(23.adjustedH)
         }
     }
 }


### PR DESCRIPTION
## 💪 작업한 내용
- picker뷰 관련 컴포넌트를 가지는 pickerViewLayout뷰의 자식 뷰가 밖으로 빠져나와 기한 설정하지 않기 버튼 클릭시 pickerViewLayout 영역 밖을 터치한 것으로 인식되어 dismiss되는 문제가 있어서 uppperCover와 lowerCover를 삭제하고 레이아웃을 다시 설정
- 기존에 고민 작성시 뿐만 아니라 수정시 WorryPostManager의 deadline 데이터를 사용하고 있는 문제가 두개의 날짜 설정 버튼 클릭시 하나의 메서드 completeDeadline을 실행하고 파라미터로 deadline 데이터를 넘겨주도록하였고
- completeDeadline에서 고민 작성, 수정인지에 따라 다른 서버통신 요청을 하도록 구분하였음
- 그리고 고민 상세뷰의 데드라인뷰를 업데이트 할때 넘겨주는 데드라인 설정값은 음수가 되도록 -를 추가했음
- 기타로 stopLoadingAnimation이 else구문에 있었어서 response를 받고 바로 실행되도록 변경하였음
- 데드라인이 남은 경우 리스폰스로 dDay가 음수로 들어오고 데드라인이 지난 경우 양수로 들어오기때문에 (deadline 정수표현 그대로 라벨에 띄워줌) 이에 따라 분기처리를 다시 해주고
- 기존에 updateUI에서 분기처리하던것을 updateDeadline 메서드를 실행하는것으로 교체하였음

추가로
- 이전 PR에서 고민 작성 창의 TVC의 텍스트 뷰의 높이 관련 코드를 수정했는데 최소 높이 제한이 적용되는것을 추가하지않아 새로 추가함
- 기존에 작성된 text를 적용한 textView의 높이가 textViewHeightConstant보다 작을때만 새로운 높이로 업데이트 시켜줌

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #128 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
