### PR TITLE
[Fix] 데드라인 설정하지 않기 데이터 전달 버그 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailFooterView.swift
@@ -50,7 +50,7 @@ final class HomeWorryDetailFooterView: UITableViewHeaderFooterView {
     
     // MARK: - Function
     func setData(updateAt: String, finalAnswer: String = "") {
-        writtenDateLabel.text = updateAt
+        writtenDateLabel.text = "작성일 " + updateAt
         answerLabel.text = finalAnswer
     }
     

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -105,8 +105,8 @@ class WritePickerVC: BaseVC {
         }
         
         noDeadlineBtn.press { [weak self] in
-            /// -888 로 데드라인 설정시 기한 설정하지 않기와 기능 동일
-            self?.completeDeadline(deadline: -888)
+            WorryPostManager.shared.deadline = -1
+            self?.completeDeadline(deadline: -1)
         }
         
     }


### PR DESCRIPTION
## 💪 작업한 내용
- 기한 설정하지 않기 클릭시에도 WorryPostManger.deadline 업데이트
- 고민 상세 작성일자 옆 작성일 문구 표시

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 서버에 보는 리퀘스트 모델을 작성할때 WorryPostManager를 통해 작성하는데 기한 설정시에만 해당 싱글톤에 deadline을 저장하고 기한 설정하지 않기 로직에서는 따로 저장하지 않아서 기본 값인 -1로 서버에 리퀘스트 모델이 만들어져서 요청되고 있었음
- 서버 로직상 -1일때도 기한 설정이 안되는것으로 설정되어 문제는 없었지만 가끔씩 기한 설정하지 않기를 해도 D-1로 되는 경우가 있었는데 이 때문이였던 것으로 보임 그래서 기한 설저하지 않기 시에도 WorryPostManager의 deadline이 -1로 설정되도록 제대로 지정


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #131 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
