### PR TITLE
[Fix] 나의 기록 수정 날짜 표시 로직수정

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -236,11 +236,12 @@ final class HomeWorryDetailVC: BaseVC {
             updateDeadline(deadline: worryDetail.dDay)
 
         case .dug:
+            reviewView.setUpdatedDate(updatedAt: worryDetail.updatedAt)
             if let finalAnswer = worryDetail.finalAnswer {
                 self.finalAnswer = finalAnswer
                 if let review = worryDetail.review {
                     self.reviewText = review.content
-                    self.reviewView.setData(content: review.content, updatedAt: review.updatedAt)
+                    self.reviewView.setReviewText(content: review.content)
                 }
             }
             navigationBarView.setTitleText(text: "나의 고민")

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDetailReviewView.swift
@@ -49,13 +49,16 @@ final class WorryDetailReviewView: UIView {
     }
     
     // MARK: - Function
-    func setData(content: String, updatedAt: String) {
-        reviewDateLabel.text = updatedAt
+    func setReviewText(content: String) {
         if !content.isEmpty {
             reviewTextView.text = content
         }else {
             reviewTextView.text = "이 고민을 통해 배운점 또는 생각을 자유롭게 적어보세요"
         }
+    }
+    
+    func setUpdatedDate(updatedAt: String) {
+        reviewDateLabel.text = updatedAt
     }
     
     private let saveButton = UIButton().then {


### PR DESCRIPTION
## 💪 작업한 내용
- 기존 나의 기록 내용과 날짜를 한번에 업데이트 해주는 메서드를 각각 따로 업데이트 할 수 있도록  메서드 분리 변경
- review 리스폰스가 null일때도 날짜가 업데이트 되도록 리스폰스의 나의 고민글 수정일자 프로퍼티로 업데이트 호출

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 본 이슈관련해 슬랙 서버 채널에 문의한 내용 첨부
```
고민상세조회 API 관련 
나의 기록의 날짜 관련 QA들어와서 확인해보니 나의기록에 날짜를 표시해야하는데 나의기록을 남기지 않은 상태에서는
리스폰스의 review 객체가 null이여서 review의 content 뿐만아니라 updateAt도 확인이 안되는 구조더라구요..
근데 해당 API 리스폰스에 나의 고민글 수정일자에 사용되는 updatedAt이 또 있더라구요 
그래서 review가 null이더라도 해당 updatedAt으로 날짜를 표시하도록 수정하였습니다.

논의 해야할것은
- 나의 기록 미 작성시에도 사진처럼 하단의 날짜는 표시 되어야 함 
  -> 근데 리스폰스의 review 객체가 null이면 날짜 확인이 안됨
- 리스폰스의 고민글 수정일자 용 upatedAt으로 나의기록 날짜도 업데이트 
  -> 일단 나의기록 수정시 해당 updatedAt도 반영이 되는지? 
  그리고 그렇게 된다면 review 객체의 updatedAt의 무의미함 (삭제? 클라 리스폰스 수정필요)
```


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #130 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
