### PR TITLE
[Fix] 고민 캐기 최종답변 관련 버그 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -35,11 +35,11 @@ final class WorryDecisionVC: BaseVC {
     private let worryTextView = UITextView().then {
         $0.backgroundColor = .kGray4
         $0.layer.cornerRadius = 8
-        $0.text = "40자 이내로 적어주세요."
+        $0.text = ""
         $0.font = .kB4R14
         $0.textColor = .kGray3
         $0.isScrollEnabled = true
-        $0.textContainerInset = UIEdgeInsets(top: 12, left: 5, bottom: 12, right: 5)
+        $0.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
     }
     
     private let doneButton = UIButton().then {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -234,7 +234,7 @@ extension WorryDecisionVC {
 extension WorryDecisionVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         var inputText = ""
-        inputText = textView.text == placeholderText ? " " : textView.text
+        inputText = textView.textColor == .kGray3 ? " " : textView.text
         /// 행간 간격 150% 설정
         let style = NSMutableParagraphStyle()
         style.lineSpacing = UIFont.kB4R14.lineHeight * 0.5

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -262,8 +262,15 @@ extension WorryDecisionVC: UITextViewDelegate {
     }
     
     func textViewDidChange(_ textView: UITextView) {
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
         
-        guard !textView.text.isEmpty else { return }
+        guard !trimmedText.isEmpty else {
+            doneButton.isEnabled = false
+            doneButton.backgroundColor = .kGray4
+            return
+        }
+        doneButton.isEnabled = true
+        doneButton.backgroundColor = .kYellow1
         
         if textView.text.count > 40 {
             textView.deleteBackward()

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -95,19 +95,18 @@ final class WorryDecisionVC: BaseVC {
     }
     
     private func setPressAction() {
-        doneButton.press {
-            self.completeWorry { success in
-                print("성공 여부", success)
+        doneButton.press { [weak self] in
+            self?.completeWorry { success in
                 if success {
-                    self.quoteView.setGemImage(templateId: self.templateId)
-                    self.showWorryQuote()
+                    self?.quoteView.setGemImage(templateId: self?.templateId ?? 1)
+                    self?.showWorryQuote()
                 /// 서버통신 실패 시 "고민 보석 캐기 실패" 알럿창 띄우기
                 } else {
                     let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
                     failureAlertVC.setTitleSubTitle(title: "고민 보석 캐기에 실패했어요", subTitle: "다시 한번 시도해주세요.", highlighting: "실패")
-                    self.present(failureAlertVC, animated: true)
+                    self?.present(failureAlertVC, animated: true)
                     failureAlertVC.OKButton.press {
-                        self.dismiss(animated: true)
+                        self?.dismiss(animated: true)
                     }
                 }
             }

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -43,12 +43,13 @@ final class WorryDecisionVC: BaseVC {
     }
     
     private let doneButton = UIButton().then {
-        $0.backgroundColor = .kYellow1
+        $0.backgroundColor = .kGray4
         $0.setTitle("완료", for: .normal)
         $0.titleLabel?.textColor = .kWhite
         $0.titleLabel?.font = .kB1B16
         $0.titleLabel?.textAlignment = .center
         $0.layer.cornerRadius = 8
+        $0.isEnabled = false
     }
     private let quoteView = WorryQuoteView().then {
         $0.backgroundColor = .kGray2


### PR DESCRIPTION
## 💪 작업한 내용
- 최종답변 미 입력시 완료 버튼 비활성화 해야하는데 해당 내용이 처리가 안되어 이번에 조치하였습니다.
- 완료버튼의 기본 상태를 disabled로 하고 버튼 배경색도 그에 따라 변경
- textView의 현재 상태가 placeHolder가 입력된건지 사용자 입력이 된 상태인지 구분하기 위해
기존에는 입력된 text가 placeHolder와 비교를 했음
- 하지만 사용자가 placeHolder 텍스트와 같게 입력하면 의도되지 않은 결과가 나오기 때문에 placeHolder 대신에 textView.textColor를 이용해서 판별
- textView의 DidChange델리게이트에서 textView의 trimmedText에 따라 버튼의 상태와 UI를 변화시켜주도록 변경

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-18 at 16 24 01](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/78d92cc8-8fd5-405d-b1cc-985c6bbfed91)


## 🚨 관련 이슈
- Resolved: #134 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
