### PR TITLE
[Fix] 고민작성 제목, 답변 델리게이트 로직 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentHeaderViewDelegate: AnyObject {
-    func titleDidEndEditing(newText: String)
+    func titleHasChanged(newText: String)
 }
 
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -113,6 +113,7 @@ extension TemplateContentTV : UITableViewDataSource
         /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
         cell.delegate = self
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], answer: answers[indexPath.row], index: indexPath.row)
+        cell.setTextViewLineStyle(hint: hints[indexPath.row])
         cell.adjustTextViewHeight()
 
         return cell

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -120,7 +120,7 @@ extension TemplateContentTV : UITableViewDataSource
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    func titleDidEndEditing(newText: String) {
+    func titleHasChanged(newText: String) {
         /// 테이블 뷰 cell이 재사용될 때 제목 값이 날라가는 걸 방지하기 위해 title 지역변수에 제목을 저장해준다.
         self.title = newText
         worryPostContent.title = title
@@ -128,7 +128,7 @@ extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentT
         buttonDelegate?.checkButtonStatus()
     }
     
-    func answerDidEndEditing(index: Int, newText: String) {
+    func answerHasChanged(index: Int, newText: String) {
         /// 테이블 뷰 값의 순서가 바뀌는 것을 막기 위해 index를 cell로 부터 받아서 answers 지역변수에 index값과 함께 저장해준다.
         self.answers[index] = newText
         worryPostContent.answers = answers

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -31,21 +31,21 @@ class TemplateContentTVC: UITableViewCell {
         $0.backgroundColor = .clear
     }
     
-    private lazy var textView = UITextView().then {
+    private let textView = UITextView().then {
         $0.isScrollEnabled = false
-        $0.delegate = self
         $0.textContainer.lineBreakMode = .byWordWrapping
         $0.textContainerInset = UIEdgeInsets(top: 18, left: 17, bottom: 18, right: 17)
         $0.backgroundColor = .kGray2
         $0.layer.cornerRadius = 12
-        $0.text = placeHolder
+        $0.text = ""
         $0.textColor = .kGray4
         $0.font = .kB2R16
     }
     
+    
+    // MARK: - Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
         setLayout()
         textView.delegate = self
     }
@@ -55,22 +55,20 @@ class TemplateContentTVC: UITableViewCell {
     }
     
     // MARK: - Functions
-    private func setLayout() {
-        contentView.backgroundColor = .kGray1
-        contentView.addSubviews([questionLabel, textView])
+    func setTextViewLineStyle(hint: String) {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = UIFont.kB2R16.lineHeight * 0.5
+        style.alignment = .justified
+        let attributedText = NSAttributedString(
+            string: hint,
+            attributes: [
+                .paragraphStyle: style,
+                .foregroundColor: UIColor.kGray4,
+                .font: UIFont.kB2R16
+            ]
+        )
         
-        questionLabel.snp.makeConstraints{
-            $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(16)
-            $0.height.equalTo(24)
-        }
-        
-        textView.snp.makeConstraints {
-            $0.top.equalTo(questionLabel.snp.bottom).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(111.adjustedH)
-            $0.bottom.equalToSuperview().offset(-54)
-        }
+        textView.attributedText = attributedText
     }
     
     func dataBind(question: String, hint: String, answer: String, index: Int) {
@@ -96,6 +94,23 @@ class TemplateContentTVC: UITableViewCell {
             textView.snp.updateConstraints {
                 $0.height.equalTo(newSizeThatFits.height)
             }
+        }
+    }
+    private func setLayout() {
+        contentView.backgroundColor = .kGray1
+        contentView.addSubviews([questionLabel, textView])
+        
+        questionLabel.snp.makeConstraints{
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
+            $0.height.equalTo(24)
+        }
+        
+        textView.snp.makeConstraints {
+            $0.top.equalTo(questionLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(111.adjustedH)
+            $0.bottom.equalToSuperview().offset(-54)
         }
     }
 }
@@ -142,11 +157,22 @@ extension TemplateContentTVC: UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-
-        if textView.textColor == .kGray4 {
-            textView.text = nil
-            textView.textColor = .kWhite
-        }
+        var inputText = ""
+        inputText = textView.textColor == .kGray4 ? " " : textView.text
+        /// 행간 간격 150% 설정
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = UIFont.kB2R16.lineHeight * 0.5
+        style.alignment = .justified
+        let attributedText = NSAttributedString(
+            string: inputText,
+            attributes: [
+                .paragraphStyle: style,
+                .foregroundColor: UIColor.kWhite,
+                .font: UIFont.kB2R16
+            ]
+        )
+        
+        textView.attributedText = attributedText
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -17,11 +17,13 @@ class TemplateContentTVC: UITableViewCell {
     
     // MARK: - Properties
     weak var delegate: TemplateContentTVCDelegate?
-    
     private var indexPath: Int = 0
-    
     private var keyboardHeight: CGFloat = 336.adjustedH
+    private let textViewHeightConstant: CGFloat = 111.adjustedH
+    private var placeHolder: String = ""
+    private var wasTextViewEmpty: Bool = true
     
+    // MARK: - Components
     private var questionLabel = UILabel().then {
         $0.text = "질문지 제목"
         $0.font = .kB1B16
@@ -29,11 +31,7 @@ class TemplateContentTVC: UITableViewCell {
         $0.backgroundColor = .clear
     }
     
-    private let textViewHeightConstant: CGFloat = 111.adjustedH
-    
-    private var placeHolder: String = ""
-            
-    lazy var textView = UITextView().then {
+    private lazy var textView = UITextView().then {
         $0.isScrollEnabled = false
         $0.delegate = self
         $0.textContainer.lineBreakMode = .byWordWrapping
@@ -103,6 +101,7 @@ class TemplateContentTVC: UITableViewCell {
 }
 
 extension TemplateContentTVC: UITextViewDelegate {
+    
     // MARK: textview 높이 자동조절
     func textViewDidChange(_ textView: UITextView) {
         
@@ -129,12 +128,17 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
-        var newText = textView.text ?? ""
-        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedText.isEmpty {
-            newText = ""
+        
+        let newText = textView.text ?? ""
+        let trimmedText = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if trimmedText.isEmpty && !wasTextViewEmpty{
+            delegate?.answerHasChanged(index: self.indexPath, newText: "")
+            wasTextViewEmpty = true
+        }else if !trimmedText.isEmpty && wasTextViewEmpty {
+            delegate?.answerHasChanged(index: self.indexPath, newText: newText)
+            wasTextViewEmpty = false
         }
-        delegate?.answerHasChanged(index: self.indexPath, newText: newText)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
@@ -152,5 +156,6 @@ extension TemplateContentTVC: UITextViewDelegate {
             textView.text = placeHolder
             textView.textColor = .kGray4
         }
+        delegate?.answerHasChanged(index: self.indexPath, newText: textView.text ?? "")
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -129,6 +129,12 @@ extension TemplateContentTVC: UITextViewDelegate {
             tableView.beginUpdates()
             tableView.endUpdates()
         }
+        var newText = textView.text ?? ""
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedText.isEmpty {
+            newText = ""
+        }
+        delegate?.answerHasChanged(index: self.indexPath, newText: newText)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
@@ -146,7 +152,5 @@ extension TemplateContentTVC: UITextViewDelegate {
             textView.text = placeHolder
             textView.textColor = .kGray4
         }
-        
-        delegate?.answerDidEndEditing(index: self.indexPath, newText: trimmedText)
     }
 }

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentTVCDelegate: AnyObject {
-    func answerDidEndEditing(index: Int, newText: String)
+    func answerHasChanged(index: Int, newText: String)
 }
 
 class TemplateContentTVC: UITableViewCell {


### PR DESCRIPTION
## 💪 작업한 내용

- 기존 타이틀 텍스트를 관리하는 텍스트 필드에서 textFieldDidEndEditing으로 사용자가 작성한 제목에 대한 정보를 넘겨줬는데 제목을 변경해도 즉각적으로 반응이 안되는 문제가 있었음
- 그래서 shouldChangeCharactersIn 델리게이트 메서드와 textDidChangeNotification 노티를통해 제목 데이터를 넘기는 것으로 수정
  - 두 개로 나눈것은 글자수가 7자 이상일때 textDidChangeNotification에서 델리게이트를 호출하므로 일부러 7자보다 작을 때만 shouldChangeCharactersIn에서 호출하도록함
- 각 호출시 trimmedText가 빈 스트링이면 델리게이트에 빈 스트링을 넘겨주도록 함

- 기존 답변 텍스트를 관리하는 텍스트뷰에서 textFieldDidEndEditing으로 사용자가 작성한 답변에 대한 정보를 넘겨줬는데 제목을 변경해도 즉각적으로 반응이 안되는 문제가 있었음
- 답변시 textView의 didChange에서 답변 텍스트 데이터를 바로바로 넘겨 델리게이트를 호출하도록 수정
- 기존에 호출하던 textFieldEndEditing 삭제

+ 해당 이슈는 아니지만 관련 코드 수정하는김에 아래 내용도 수정
- textView 로드시 textView의 paragraphStyle를 바로 설정할 수 있도록 setTextViewLineStyle() 메서드를 구현해 TV에서 호출해서 적용되도록 함 (textView 정의 부분에서 attributedText가 적용이 제대로 안되어 따로 함수로 구현하여 호출)

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 성능상으로 텍스트를 입력할 때마다 델리게이트 호출하니까 좋은 것 같지 않은데 그래도 사용자 입장에서 즉각적으로 버튼 업데이트가 되는게 직관적인 것 같아서 QA들어온건 아닌데 개인적으로 신경쓰여 수정하였습니다.. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-18 at 18 22 10](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/b1d67aad-3ba4-4133-9cca-2ff1e9b30bc6)


## 🚨 관련 이슈
- Resolved: #136 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
