### PR TITLE
[Fix] 고민수정 시 기존 답변 내용 적용 안됨 버그 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -110,10 +110,8 @@ extension TemplateContentTV : UITableViewDataSource
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TemplateContentTVC.classIdentifier, for: indexPath) as? TemplateContentTVC else {return UITableViewCell()}
         
-        /// cell에서 endEditing 시에 적힌 값을 TV로 보내준다.
         cell.delegate = self
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], answer: answers[indexPath.row], index: indexPath.row)
-        cell.setTextViewLineStyle(hint: hints[indexPath.row])
         cell.adjustTextViewHeight()
 
         return cell

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTVC.swift
@@ -55,15 +55,15 @@ class TemplateContentTVC: UITableViewCell {
     }
     
     // MARK: - Functions
-    func setTextViewLineStyle(hint: String) {
+    func setTextViewStyle(inputText: String, textColor: UIColor) {
         let style = NSMutableParagraphStyle()
         style.lineSpacing = UIFont.kB2R16.lineHeight * 0.5
         style.alignment = .justified
         let attributedText = NSAttributedString(
-            string: hint,
+            string: inputText,
             attributes: [
                 .paragraphStyle: style,
-                .foregroundColor: UIColor.kGray4,
+                .foregroundColor: textColor,
                 .font: UIFont.kB2R16
             ]
         )
@@ -77,11 +77,9 @@ class TemplateContentTVC: UITableViewCell {
         self.indexPath = index
         
         if answer.isEmpty {
-            textView.text = placeHolder
-            textView.textColor = .kGray4
+            setTextViewStyle(inputText: placeHolder,textColor: .kGray4)
         } else {
-            textView.text = answer
-            textView.textColor = .kWhite
+            setTextViewStyle(inputText: answer, textColor: .kWhite)
         }
     }
     
@@ -159,20 +157,7 @@ extension TemplateContentTVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         var inputText = ""
         inputText = textView.textColor == .kGray4 ? " " : textView.text
-        /// 행간 간격 150% 설정
-        let style = NSMutableParagraphStyle()
-        style.lineSpacing = UIFont.kB2R16.lineHeight * 0.5
-        style.alignment = .justified
-        let attributedText = NSAttributedString(
-            string: inputText,
-            attributes: [
-                .paragraphStyle: style,
-                .foregroundColor: UIColor.kWhite,
-                .font: UIFont.kB2R16
-            ]
-        )
-        
-        textView.attributedText = attributedText
+        setTextViewStyle(inputText: inputText, textColor: .kWhite)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {


### PR DESCRIPTION
## 💪 작업한 내용
- 기존 setTextViewLineStyle 메서드를 테이블 뷰에서 직접 실행했는데 메서드에 placeHolder 텍스트를 입력하는 것으로 고정되어 있어 고민 수정시 기존 입력된 답변이 제대로 입력이 안되는 문제가 생김
- 그래서 setTextViewStyle로 메서드 명을 바꾸고 TVC내에서 dataBind 메서드 내에서 답변 텍스트의 isEmpty 여부에 따라 동작할 수 있도록 파라미터로 inputText와 textColor를 추가하여 구현
- 그리고 textViewDidBeginEditing에서의 동작을 대체 할 수 있어 해당 메서드를 호출하는 것으로 대체

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #142 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
