### PR TITLE
[Fix] 고민작성API 리스폰스 수정

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		E72D6AF32B1C907800CF8B01 /* EditWorryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D6AF22B1C907800CF8B01 /* EditWorryResponseModel.swift */; };
 		E72D6AF62B21E1A500CF8B01 /* WriteEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D6AF52B21E1A500CF8B01 /* WriteEmptyView.swift */; };
 		E73A4C162B31234600C019EF /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E73A4C152B31234600C019EF /* Settings.bundle */; };
+		E73A4C182B3433EF00C019EF /* WorryContentResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A4C172B3433EF00C019EF /* WorryContentResponseModel.swift */; };
 		E73CA3DA2A69300F00BAC9D6 /* HomePublisherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */; };
 		E73CA3DC2A693C9D00BAC9D6 /* GemStoneEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */; };
 		E73CA3DF2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */; };
@@ -200,6 +201,7 @@
 		E72D6AF22B1C907800CF8B01 /* EditWorryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWorryResponseModel.swift; sourceTree = "<group>"; };
 		E72D6AF52B21E1A500CF8B01 /* WriteEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteEmptyView.swift; sourceTree = "<group>"; };
 		E73A4C152B31234600C019EF /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		E73A4C172B3433EF00C019EF /* WorryContentResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryContentResponseModel.swift; sourceTree = "<group>"; };
 		E73CA3D92A69300F00BAC9D6 /* HomePublisherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePublisherModel.swift; sourceTree = "<group>"; };
 		E73CA3DB2A693C9D00BAC9D6 /* GemStoneEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GemStoneEmptyView.swift; sourceTree = "<group>"; };
 		E73CA3DE2A6A62F700BAC9D6 /* HomeWorryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWorryDetailVC.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 			children = (
 				85887D8B2A5D084800F7FB21 /* TemplateListModel.swift */,
 				85A8492C2A87A3FF009F1468 /* TemplateContentModel.swift */,
+				E73A4C172B3433EF00C019EF /* WorryContentResponseModel.swift */,
 			);
 			name = Model;
 			path = ../Archive/Model;
@@ -954,6 +957,7 @@
 				E7BB4F512A5EF8260018312B /* WorryListModel.swift in Sources */,
 				E79AAC392A52F2C300F3F439 /* UICollectionVIew+.swift in Sources */,
 				E7B94D702ADDF9B8005D9FB8 /* MyPageTVC.swift in Sources */,
+				E73A4C182B3433EF00C019EF /* WorryContentResponseModel.swift in Sources */,
 				E7F8CC652B10712600066BB1 /* CustomPageControl.swift in Sources */,
 				85EBC7F72A5AD95D00B9E891 /* ArchiveVC.swift in Sources */,
 				E79AAC432A52F36500F3F439 /* APIConstant.swift in Sources */,

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -13,10 +13,7 @@ final class WriteAPI {
     
     static let shared: WriteAPI = WriteAPI()
     private let writeProvider = MoyaProvider<WriteService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
-    
-    // tableView의 데이터들을 담는 싱글톤 클래스
-    let contentInfo = WorryPostManager.shared
-    
+
     private init() { }
     
     public private(set) var templateListResponse: GeneralArrayResponse<TemplateListModel>?

--- a/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/TemplateContentModel.swift
@@ -22,8 +22,3 @@ struct WorryContentRequestModel: Codable {
     var answers: [String]
     var deadline: Int
 }
-
-struct WorryContentResponseModel: Codable {
-    let createdAt: String
-    let deadline: String
-}

--- a/KAERA/KAERA/Scenes/Archive/Model/WorryContentResponseModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/WorryContentResponseModel.swift
@@ -1,0 +1,19 @@
+//
+//  WriteResponseModel.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/12/21.
+//
+
+import Foundation
+
+struct WorryContentResponseModel: Codable {
+    let worryId: Int
+    let title: String
+    let templateId: Int
+    let subtitles: [String]
+    let answers: [String]
+    let createdAt: String
+    let deadline: String
+    let dDay: Int
+}

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -132,7 +132,7 @@ class WritePickerVC: BaseVC {
     private func postWorryContent(postWorryContent: WorryContentRequestModel) {
         startLoadingAnimation()
         WriteAPI.shared.postWorryContent(param: postWorryContent) { [weak self] result in
-            guard let result = result, let _ = result.data else {
+            guard let result = result, let data = result.data else {
                 self?.presentNetworkAlert()
                 return
             }
@@ -141,6 +141,7 @@ class WritePickerVC: BaseVC {
                 UIView.animate(withDuration: 0.5, animations: {
                     self?.pickerViewLayout.alpha = 0
                 }) { [weak self] _ in
+                    // TODO: 고민 작성 후 해당 고민 상세로 이동
                     self?.dismiss(animated: false) {
                         writeVC.dismiss(animated: true)
                     }


### PR DESCRIPTION
## 💪 작업한 내용
- [노션 내용](https://www.notion.so/1217-8aac987501d4496ea65c2515087e89fb?pvs=4)처럼 고민 작성시 작성된 고민 상세 페이지로 바로 이동하기 위해 고민작성 리스폰스에 고민상세 내용을 추가해 리스폰스 수정이 되었음
- 이에 따라 worryContentResponseModel 내용 업데이트
  - 기존에 다른 파일 내부에 있던 것을 따로 새파일로 만들어 추가


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #147


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
