### PR TITLE
[Fix] 고민작성 시 제목 마지막 글자 자/모 분리 문제 해결

### DIFF
--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentHeaderViewDelegate: AnyObject {
-    func titleHasChanged(checkText: Bool, newText: String)
+    func titleHasChanged(newText: String)
 }
 
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
@@ -101,7 +101,7 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
                     if trimmedText.isEmpty {
                         newText = ""
                     }
-                    delegate?.titleHasChanged(checkText: false, newText: newText)
+                    delegate?.titleHasChanged(newText: newText)
                 }
             }
         }
@@ -137,7 +137,7 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
                 newText = ""
             }
             /// 단순히 "완료" 버튼 활성화를 위한 delegate
-            delegate?.titleHasChanged(checkText: true, newText: newText)
+            delegate?.titleHasChanged(newText: newText)
         }
         return true
     }
@@ -149,14 +149,10 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
         titleNumLabel.attributedText = attributedString
     }
     
+    /// 제목작성이 끝나는 시점에서 delegate를 추가로 실행하여 온전한 제목 전송
     func textFieldDidEndEditing(_ textField: UITextField) {
         let inputText = textField.text ?? ""
-        if inputText.count < maxLength {
-            /// 실제 제목 값은 textfieldEndEditing 시에만 변경
-            delegate?.titleHasChanged(checkText: false, newText: inputText)
-        }
-        /// textfieldEndEditing 시에 버튼 활성화 여부 다시 체크
-        delegate?.titleHasChanged(checkText: true, newText: inputText)
+        delegate?.titleHasChanged(newText: inputText)
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentHeaderView.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 protocol TemplateContentHeaderViewDelegate: AnyObject {
-    func titleHasChanged(newText: String)
+    func titleHasChanged(checkText: Bool, newText: String)
 }
 
 final class TemplateContentHeaderView: UITableViewHeaderFooterView {
@@ -101,8 +101,7 @@ final class TemplateContentHeaderView: UITableViewHeaderFooterView {
                     if trimmedText.isEmpty {
                         newText = ""
                     }
-                    delegate?.titleHasChanged(newText: newText)
-
+                    delegate?.titleHasChanged(checkText: false, newText: newText)
                 }
             }
         }
@@ -127,7 +126,7 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
             let isBackSpace = strcmp(char, "\\b")
             if isBackSpace == -92 {
                 newText = String(newText.dropLast())
-            }else {
+            } else {
                 newText = newText + string
             }
         }
@@ -137,7 +136,8 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
             if trimmedText.isEmpty {
                 newText = ""
             }
-            delegate?.titleHasChanged(newText: newText)
+            /// 단순히 "완료" 버튼 활성화를 위한 delegate
+            delegate?.titleHasChanged(checkText: true, newText: newText)
         }
         return true
     }
@@ -147,6 +147,16 @@ extension TemplateContentHeaderView: UITextFieldDelegate {
         let attributedString = NSMutableAttributedString(string: "\(worryTitleTextField.text!.count)/7")
         attributedString.addAttribute(.foregroundColor, value: UIColor.kWhite, range: ("\(worryTitleTextField.text!.count)/7" as NSString).range(of:"\(worryTitleTextField.text!.count)"))
         titleNumLabel.attributedText = attributedString
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        let inputText = textField.text ?? ""
+        if inputText.count < maxLength {
+            /// 실제 제목 값은 textfieldEndEditing 시에만 변경
+            delegate?.titleHasChanged(checkText: false, newText: inputText)
+        }
+        /// textfieldEndEditing 시에 버튼 활성화 여부 다시 체크
+        delegate?.titleHasChanged(checkText: true, newText: inputText)
     }
 }
 

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -119,14 +119,17 @@ extension TemplateContentTV : UITableViewDataSource
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    func titleHasChanged(newText: String) {
+    func titleHasChanged(checkText: Bool, newText: String) {
         /// 테이블 뷰 cell이 재사용될 때 제목 값이 날라가는 걸 방지하기 위해 title 지역변수에 제목을 저장해준다.
-        self.title = newText
-        worryPostContent.title = title
-        worryPatchContent.title = title
-        buttonDelegate?.checkButtonStatus()
+        if checkText == true {
+            buttonDelegate?.checkButtonStatus()
+        } else {
+            self.title = newText
+            worryPostContent.title = title
+            worryPatchContent.title = title
+        }
     }
-    
+        
     func answerHasChanged(index: Int, newText: String) {
         /// 테이블 뷰 값의 순서가 바뀌는 것을 막기 위해 index를 cell로 부터 받아서 answers 지역변수에 index값과 함께 저장해준다.
         self.answers[index] = newText

--- a/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/TemplateContentTV.swift
@@ -113,23 +113,20 @@ extension TemplateContentTV : UITableViewDataSource
         cell.delegate = self
         cell.dataBind(question: questions[indexPath.row], hint: hints[indexPath.row], answer: answers[indexPath.row], index: indexPath.row)
         cell.adjustTextViewHeight()
-
+        
         return cell
     }
 }
 
 extension TemplateContentTV: TemplateContentHeaderViewDelegate, TemplateContentTVCDelegate {
-    func titleHasChanged(checkText: Bool, newText: String) {
+    func titleHasChanged(newText: String) {
         /// 테이블 뷰 cell이 재사용될 때 제목 값이 날라가는 걸 방지하기 위해 title 지역변수에 제목을 저장해준다.
-        if checkText == true {
-            buttonDelegate?.checkButtonStatus()
-        } else {
-            self.title = newText
-            worryPostContent.title = title
-            worryPatchContent.title = title
-        }
+        self.title = newText
+        worryPostContent.title = title
+        worryPatchContent.title = title
+        buttonDelegate?.checkButtonStatus()
     }
-        
+    
     func answerHasChanged(index: Int, newText: String) {
         /// 테이블 뷰 값의 순서가 바뀌는 것을 막기 위해 index를 cell로 부터 받아서 answers 지역변수에 index값과 함께 저장해준다.
         self.answers[index] = newText


### PR DESCRIPTION
## 💪 작업한 내용
- 고민 작성시에 제목의 마지막 글자의 자/모가 분리되는 현상을 해결했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- @daminoworld 님이 코드 리펙토링을 위해 textfieldDidChangeSelection에 위치해있던 제목의 변경을 확인하는 titleHasChanged delegate 위치를 shouldChangeCharactersIn로 변경하면서 텍스트 반영이 한박자씩 늦게되는 문제가 발생했습니다. 

![IMG_F7175861367B-1](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/0eccc10e-e004-48fe-8898-4367cedcd33c)

**textFieldDidEndEditing**에 delegate를 추가하여 텍스트필드가 변경된 이후에 완성된 문자열이 title 변수에 저장되게끔 하였습니다. 

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-26 at 14 14 25](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/df26e1a2-858a-44ce-a26f-6652ab971cae)


## 🚨 관련 이슈
- Resolved: #145 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
