### PR TITLE
[Fix] 고민 상세 API 리스폰스 변경 사항 반영

### DIFF
--- a/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/WorryDetailModel.swift
@@ -15,17 +15,13 @@ struct WorryDetailModel: Codable {
     let period, updatedAt, deadline: String
     let dDay: Int
     let finalAnswer: String?
-    let review: Review?
-    
-    enum CodingKeys : String, CodingKey {
-        case dDay = "d-day"
-        case title, templateId, subtitles, answers, period, updatedAt, deadline, finalAnswer, review
-    }
+    let review: Review
 }
 
 // MARK: - Review
 struct Review: Codable {
-    let content, updatedAt: String
+    let content: String?
+    let updatedAt: String?
 }
 
 struct PatchDeadlineModel: Codable {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -236,15 +236,19 @@ final class HomeWorryDetailVC: BaseVC {
             updateDeadline(deadline: worryDetail.dDay)
 
         case .dug:
-            reviewView.setUpdatedDate(updatedAt: worryDetail.updatedAt)
+            navigationBarView.setTitleText(text: "나의 고민")
+
             if let finalAnswer = worryDetail.finalAnswer {
                 self.finalAnswer = finalAnswer
-                if let review = worryDetail.review {
-                    self.reviewText = review.content
-                    self.reviewView.setReviewText(content: review.content)
-                }
             }
-            navigationBarView.setTitleText(text: "나의 고민")
+            if let content = worryDetail.review.content {
+                self.reviewText = content
+                self.reviewView.setReviewText(content: content)
+            }
+            
+            if let updatedAt = worryDetail.review.updatedAt {
+                reviewView.setUpdatedDate(updatedAt: updatedAt)
+            }
         }
         
         /// 갱신된 데이터로 테이블뷰 정보를 갱신


### PR DESCRIPTION
## 💪 작업한 내용
- 기존 review가 null일때 updatedAt을 확인 할 수 없었어서 review가 아닌 content와 updatedAt을 null일 수 있게 설정하여 이에 따라 리스폰스 모델 수정
- 고민 상세 API 명세서 리스폰스 모델의 데이터 타입 변경 (review의 content, updatedAt)에 따른 바인딩 처리


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #151 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
