### PR TITLE
[Fix] 기한 설정하지 않기 설정시 dDay 오류 수정

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		E79AAC4A2A52F3E000F3F439 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC482A52F3E000F3F439 /* BaseVC.swift */; };
 		E79AAC4B2A52F3E000F3F439 /* BaseNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC492A52F3E000F3F439 /* BaseNC.swift */; };
 		E79AAC5A2A531E3300F3F439 /* NanumMyeongjoOTF.otf in Resources */ = {isa = PBXBuildFile; fileRef = E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */; };
+		E7A3A2822B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A3A2812B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift */; };
 		E7A94CC42AA484E300F231D0 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A94CC32AA484E300F231D0 /* SignInVC.swift */; };
 		E7A94CC72AA6A46800F231D0 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CC62AA6A46800F231D0 /* KakaoSDKAuth */; };
 		E7A94CC92AA6A46800F231D0 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CC82AA6A46800F231D0 /* KakaoSDKCommon */; };
@@ -240,6 +241,7 @@
 		E79AAC482A52F3E000F3F439 /* BaseVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		E79AAC492A52F3E000F3F439 /* BaseNC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseNC.swift; sourceTree = "<group>"; };
 		E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumMyeongjoOTF.otf; sourceTree = "<group>"; };
+		E7A3A2812B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDeadlineUpdateResponseModel.swift; sourceTree = "<group>"; };
 		E7A94CC12AA4569300F231D0 /* KAERA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KAERA.entitlements; sourceTree = "<group>"; };
 		E7A94CC32AA484E300F231D0 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		E7A94CCC2AAC149900F231D0 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
@@ -696,6 +698,7 @@
 				85831C312AF0F5F2008839A0 /* CompleteWorryModel.swift */,
 				E72D6AF22B1C907800CF8B01 /* EditWorryResponseModel.swift */,
 				E772E70C2AF9AE650098E091 /* HomeGemStoneCount.swift */,
+				E7A3A2812B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -955,6 +958,7 @@
 				E70764752AC06B6000627AA7 /* KeyChainManager.swift in Sources */,
 				E79AAC3D2A52F2C300F3F439 /* UIFont+.swift in Sources */,
 				85887D8E2A5D086300F7FB21 /* TemplateViewModel.swift in Sources */,
+				E7A3A2822B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift in Sources */,
 				85ECEE4D2A9B821500A624AE /* WriteAPI.swift in Sources */,
 				E7BB4F492A5EF7320018312B /* HomeGemListModel.swift in Sources */,
 				E7BB4F512A5EF8260018312B /* WorryListModel.swift in Sources */,

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -19,7 +19,7 @@ final class HomeAPI {
     public private(set) var homeGemListResponse: GeneralArrayResponse<HomeGemListModel>?
     public private(set) var worryDetailResponse: GeneralResponse<WorryDetailModel>?
     public private(set) var deleteWorryResponse: EmptyResponse?
-    public private(set) var updateDeadlineResponse: GeneralResponse<String>?
+    public private(set) var updateDeadlineResponse: GeneralResponse<WorryDeadlineUpdateResponseModel>?
     public private(set) var editWorryResponse: GeneralResponse<EditWorryResponseModel>?
     public private(set) var completeWorryResponse: GeneralResponse<QuoteModel>?
     public private(set) var worryReviewResponse: GeneralResponse<WorryReviewResponseModel>?
@@ -83,18 +83,18 @@ final class HomeAPI {
     }
     
     // MARK: - UpdateDeadline
-    func updateDeadline(param: PatchDeadlineModel, completion: @escaping (GeneralResponse<String>?) -> ()) {
+    func updateDeadline(param: PatchDeadlineModel, completion: @escaping (GeneralResponse<WorryDeadlineUpdateResponseModel>?) -> ()) {
         homeProvider.request(.updateDeadline(param: param)) { [weak self] response in
             switch response {
             case .success(let result):
                 do {
-                    self?.updateDeadlineResponse = try result.map(GeneralResponse<String>?.self)
+                    self?.updateDeadlineResponse = try result.map(GeneralResponse<WorryDeadlineUpdateResponseModel>?.self)
                     guard let response = self?.updateDeadlineResponse else { return }
                     
                     if 200..<300 ~= response.status {
                         completion(response)
                     } else {
-                        completion(response)
+                        completion(nil)
                     }
                     
                 } catch(let err) {

--- a/KAERA/KAERA/Scenes/Home/Model/WorryDeadlineUpdateResponseModel.swift
+++ b/KAERA/KAERA/Scenes/Home/Model/WorryDeadlineUpdateResponseModel.swift
@@ -1,0 +1,13 @@
+//
+//  WorryDeadlineUpdateResponseModel.swift
+//  KAERA
+//
+//  Created by 김담인 on 2023/12/26.
+//
+
+import Foundation
+
+struct WorryDeadlineUpdateResponseModel: Codable {
+    let deadline: String
+    let dDay: Int
+}

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -154,9 +154,9 @@ class WritePickerVC: BaseVC {
     
     func patchWorryDeadline(deadlineContent: PatchDeadlineModel) {
         self.startLoadingAnimation()
-        HomeAPI.shared.updateDeadline(param: deadlineContent) { [weak self] response in
+        HomeAPI.shared.updateDeadline(param: deadlineContent) { [weak self] result in
             self?.stopLoadingAnimation()
-            guard let _ = response else {
+            guard let result, let data = result.data else {
                 let failureAlertVC = KaeraAlertVC(buttonType: .onlyOK, okTitle: "확인")
                 failureAlertVC.setTitleSubTitle(title: "일자 수정에 실패했어요", subTitle: "다시 한번 시도해주세요.", highlighting: "실패")
                 self?.present(failureAlertVC, animated: true)
@@ -164,7 +164,7 @@ class WritePickerVC: BaseVC {
             }
             if let editVC = self?.presentingViewController {
                 if let detailVC = editVC.presentingViewController as? HomeWorryDetailVC {
-                    detailVC.updateDeadline(deadline: -deadlineContent.dayCount)
+                    detailVC.updateDeadline(deadline: data.dDay)
                 }
                 UIView.animate(withDuration: 0.5, animations: {
                     self?.pickerViewLayout.alpha = 0


### PR DESCRIPTION
## 💪 작업한 내용
-  기존에 서버 요청 메서드의 파라미터로 넘겨 받은 dayCount를 사용했는데 이럴경우 기한 설정하지 않기 시 -1로 디데이가 설정됨
- 데드라인 업데이트 API 의 리스폰스에 '기한 설정하지 않기'시 dDay가 -888로 오기 때문에 이를 이용해 디데이 정보를 설정하도록 리스폰스 모델을 새로 만들고 이를 받아서 디데이를 설정하도록 수정


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
-  기존에 노션 데드라인 수정 API 명세서 처럼 리스폰스로 deadline만 넘어왔어서 따로 모델을 만들지 않았는데 지금 확인해보니 리스폰스가 바뀌어 있네요..ㅎㅎ 서버쪽에 명세서 수정 요청하고 새로 모델을 만들어서 적용하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #148 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
