### PR TITLE
[Fix] 고민작성 내 템플릿 변경시 templateId 반영 안되는 이슈

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveTemplateInfo/TemplateInfoVC.swift
@@ -120,7 +120,7 @@ class TemplateInfoVC: BaseVC, TemplateInfoTVCDelegate {
     
     // MARK: - TemplateInfoTVCDelegate
     func didPressWritingButton(templateId: Int) {
-        let writeVC = WriteVC(type: .postDifferentTemplate)
+        let writeVC = WriteVC(type: .post)
         writeVC.modalPresentationStyle = .fullScreen
         self.present(writeVC, animated: true, completion: nil)
         writeVC.templateReload(templateId: templateId)

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -12,9 +12,7 @@ import Then
 
 enum WriteType {
     case post
-    case postDifferentTemplate
     case patch
-    case patchDifferentTemplate
 }
 
 final class WriteVC: BaseVC {
@@ -136,7 +134,7 @@ final class WriteVC: BaseVC {
         
         navigationBarView.setRightButtonAction  { [weak self] in
             switch self?.writeType {
-            case .post, .postDifferentTemplate:
+            case .post:
                 if WorryPostManager.shared.title.isEmpty {
                     self?.showToastMessage(message: "고민의 제목을 붙여주세요!", color: .black)
                 } else if self?.checkEmptyAnswer() ?? true {
@@ -153,7 +151,7 @@ final class WriteVC: BaseVC {
                         })
                     })
                 }
-            case .patch, .patchDifferentTemplate:
+            case .patch:
                 if WorryPostManager.shared.title.isEmpty {
                     self?.showToastMessage(message: "고민의 제목을 붙여주세요!", color: .black)
                 } else if self?.checkEmptyAnswer() ?? true {
@@ -172,9 +170,9 @@ final class WriteVC: BaseVC {
     private func checkEmptyAnswer() -> Bool {
         var answers: [String] = []
         switch writeType {
-        case .post, .postDifferentTemplate:
+        case .post:
             answers = WorryPostManager.shared.answers
-        case .patch, .patchDifferentTemplate:
+        case .patch:
             answers = WorryPatchManager.shared.answers
         }
         /// answers가 아예 빈 배열일때 처리
@@ -193,9 +191,9 @@ final class WriteVC: BaseVC {
         self.present(failureAlertVC, animated: true)
         failureAlertVC.OKButton.press { [weak self] in
             switch self?.writeType {
-            case .post, .postDifferentTemplate:
+            case .post:
                 WorryPostManager.shared.clearWorryData()
-            case .patch, .patchDifferentTemplate:
+            case .patch:
                 WorryPatchManager.shared.clearWorryData()
             case .none:
                 break
@@ -212,11 +210,11 @@ final class WriteVC: BaseVC {
         var answers: [String] = []
         
         switch self.writeType {
-        case .post, .postDifferentTemplate:
+        case .post:
             title = WorryPostManager.shared.title
             answers = WorryPostManager.shared.answers
             /// 고민 작성 시를 제외하고는 템플릿 변경 시 알럿 창을 띄워주어야 한다.
-        case .patch, .patchDifferentTemplate:
+        case .patch:
             title = WorryPatchManager.shared.title
             answers = WorryPatchManager.shared.answers
         }
@@ -247,9 +245,9 @@ final class WriteVC: BaseVC {
         self.present(failureAlertVC, animated: true)
         failureAlertVC.OKButton.press { [weak self] in
             switch self?.writeType {
-            case .post, .postDifferentTemplate:
+            case .post:
                 WorryPostManager.shared.answers = []
-            case .patch, .patchDifferentTemplate:
+            case .patch:
                 WorryPatchManager.shared.answers = []
             case .none:
                 break
@@ -327,10 +325,8 @@ extension WriteVC: TemplateIdDelegate {
         input.send(templateId)
         // 처음 고민작성시 템플릿을 선택했을때 writeType을 바꿔줌
         if writeType == .post {
-            self.writeType = .postDifferentTemplate
             WorryPostManager.shared.templateId = templateId
         }else if writeType == .patch {
-            self.writeType = .patchDifferentTemplate
             WorryPatchManager.shared.templateId = templateId
             self.tempAnswers = []
         }
@@ -343,9 +339,9 @@ extension WriteVC: ActivateButtonDelegate {
     func checkButtonStatus() {
         var isTitleEmpty = true
         switch self.writeType {
-        case .post, .postDifferentTemplate:
+        case .post:
             isTitleEmpty = WorryPostManager.shared.title.isEmpty
-        case .patch, .patchDifferentTemplate:
+        case .patch:
             isTitleEmpty = WorryPatchManager.shared.title.isEmpty
         }
         


### PR DESCRIPTION
## 💪 작업한 내용
-  기존에 고민 작성시 템플릿을 선택 혹은 변경시 호출된는 templateReload 메서드에서 writeType로 분기처리해서 templateId를 업데이트 해줬는데 -DifferentTemplate 케이스일때 업데이트 하는 로직을 타지 않아서 기존 선택된 템플릿 아이디로 고민작성 요청이 되는 문제가 있었습니다.
- 그래서 현재 코드에서 DifferentTemplate를 구분해야 할 필요가 없어 아예 케이스를 삭제하고 관련 코드도 수정하였습니다.


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기존에 고민상세에 noData가 뜨는게 이번 이슈 때문이였네요...
- DifferentTemplate가 사용되는 코드를 다 확인해 봤는데 구분할 필요가 없어 삭제하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-26 at 18 30 17](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/5725e6db-1166-4683-9a22-10b297901283)


## 🚨 관련 이슈
- Resolved: #156  


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
