### PR TITLE
[Fix] 고민수정 시 완료 버튼 활성화되게끔 변경

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -90,6 +90,7 @@ final class HomeWorryEditVC: BaseVC {
             
             self?.worryPatchContent.worryId =  self?.worryId ?? 0
             self?.worryPatchContent.templateId = templateId
+            writeVC.setupDoneButton(status: true)
             writeVC.input.send(templateId)
         }
         

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -132,7 +132,7 @@ class WritePickerVC: BaseVC {
     private func postWorryContent(postWorryContent: WorryContentRequestModel) {
         startLoadingAnimation()
         WriteAPI.shared.postWorryContent(param: postWorryContent) { [weak self] result in
-            guard let result = result, let data = result.data else {
+            guard let result = result, let _ = result.data else {
                 self?.presentNetworkAlert()
                 return
             }

--- a/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WriteVC.swift
@@ -350,10 +350,14 @@ extension WriteVC: ActivateButtonDelegate {
         }
         
         if isTitleEmpty || self.checkEmptyAnswer() {
-            navigationBarView.setupDoneButtonStatus(status: false)
+            setupDoneButton(status: false)
         } else {
-            navigationBarView.setupDoneButtonStatus(status: true)
+            setupDoneButton(status: true)
         }
+    }
+    
+    func setupDoneButton(status: Bool) {
+        navigationBarView.setupDoneButtonStatus(status: status)
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
- 고민수정 시에 글을 따로 수정하지 않아도 완료 버튼이 활성화 되있게끔 변경


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 함수를 추가하여 버튼 status를 관리


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-27 at 13 29 15](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/0af24bac-f85c-49c2-a3b3-fcea32749799)


## 🚨 관련 이슈
- Resolved: #146 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
