### PR TITLE
[Fix] 글 삭제 시 고민보관함 reload 안되는 이슈 해결

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -183,9 +183,9 @@ extension ArchiveVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("indexPath?: ", indexPath.row)
         let worryDetailVC = HomeWorryDetailVC(worryId: worryListWithTemplate[indexPath.row].worryId, type: .dug)
-        worryDetailVC.modalPresentationStyle = .overFullScreen
+        worryDetailVC.modalPresentationStyle = .fullScreen
         worryDetailVC.modalTransitionStyle = .coverVertical
-        self.present(worryDetailVC, animated: true)
+        self.present(worryDetailVC, animated: true, completion: nil)
     }
 }
 

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -181,11 +181,10 @@ extension ArchiveVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("indexPath?: ", indexPath.row)
         let worryDetailVC = HomeWorryDetailVC(worryId: worryListWithTemplate[indexPath.row].worryId, type: .dug)
         worryDetailVC.modalPresentationStyle = .fullScreen
         worryDetailVC.modalTransitionStyle = .coverVertical
-        self.present(worryDetailVC, animated: true, completion: nil)
+        self.present(worryDetailVC, animated: true)
     }
 }
 


### PR DESCRIPTION
## 💪 작업한 내용
- 고민보관함 reload가 안되는 이슈를 해결했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- @daminoworld 님이 짠 홈뷰와 코드를 비교해본 결과 modalPresentationStyle이 다른 것을 확인하고 .overFullScreen으로 되어 있던 modal방식을 .fullScreen으로 변경해보니 collectionView reload가 잘 되었습니다. 

> 그 이유는 아래와 같았습니다. 
1. .fullScreen:
모달 뷰 컨트롤러가 .fullScreen으로 표시될 때, 전체 화면을 덮고, 기존 뷰 컨트롤러의 뷰는 전환 완료 후 뷰 계층에서 제거됩니다. 이는 모달 뷰 컨트롤러를 닫을 때, 기존 뷰 컨트롤러의 뷰가 뷰 계층에 다시 추가되고, 이로 인해 viewWillAppear(_:), viewDidAppear(_:)와 같은 레이아웃 관련 호출이 발생한다는 것을 의미합니다.

2. .overFullScreen:
.overFullScreen으로 모달이 표시되면, 기존 뷰 컨트롤러의 콘텐츠 위에 모달 뷰 컨트롤러가 표시됩니다. 여기서 중요한 점은 기존 뷰 컨트롤러의 뷰 계층이 수정되지 않고 그대로 유지된다는 것입니다.이 프레젠테이션 스타일은 모달이 닫혔을 때 기존 뷰가 뷰 계층에서 벗어나지 않았기 때문에 동일한 레이아웃 관련 호출을 발생시키지 않습니다.

.fullScreen인 경우 뷰 생명주기 메소드(viewWillAppear, viewDidAppear)가 호출되었기 때문에 만약 모달 뷰 컨트롤러가 닫힌 후 collectionView가 리로드되고, .overFullScreen으로 설정하였을 때는 리로드되지 않았던 것이었습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-12-27 at 13 42 40](https://github.com/TeamHARA/KAERA_iOS/assets/45239582/909a4104-3faf-4297-aa90-5f8209195830)


## 🚨 관련 이슈
- Resolved: #159 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
