### PR TITLE
[Feat] 고민 작성시 고민 상세 이동 로직 구현

### DIFF
--- a/KAERA/KAERA/Scenes/Auth/Model/MyPageDataType.swift
+++ b/KAERA/KAERA/Scenes/Auth/Model/MyPageDataType.swift
@@ -37,7 +37,6 @@ struct MyPageAccountAlertInfoModel {
     let type: AccountActionType
 }
 
-//TODO: API나오면 서버 리스폰스 모델로 교체
 struct MyPageURLModel {
     let manual: String
     let instagram: String

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryEditVC.swift
@@ -100,8 +100,6 @@ final class HomeWorryEditVC: BaseVC {
             pickerVC.modalPresentationStyle = .fullScreen
             pickerVC.modalTransitionStyle = .coverVertical
             pickerVC.view.alpha = 0 /// pickerView를 초기에 보이지 않게 설정
-            ///
-            pickerVC.modalPresentationStyle = .overCurrentContext
             self?.present(pickerVC, animated: false, completion: { /// 애니메이션을 false로 설정
                 UIView.animate(withDuration: 0.5, animations: { /// 애니메이션 추가
                     pickerVC.view.alpha = 1 /// pickerView가 서서히 보이게 설정

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -145,8 +145,9 @@ final class WorryDecisionVC: BaseVC {
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
             if let worryDetailVC = self.presentingViewController {
-                self.dismiss(animated: true)
-                worryDetailVC.dismiss(animated: true)
+                self.dismiss(animated: true) {
+                    worryDetailVC.dismiss(animated: true)
+                }
             }
         }
     }

--- a/KAERA/KAERA/Scenes/KaeraTabbarController.swift
+++ b/KAERA/KAERA/Scenes/KaeraTabbarController.swift
@@ -85,11 +85,13 @@ extension KaeraTabbarController: UITabBarControllerDelegate {
                 alertVC.setTitleSubTitle(title: "고민 원석이 가득찼어요!", subTitle: "너무 많은 고민은 머릿 속을 어지럽혀요 \n다른 고민들을 끝낸 다음, 새 원석을 생성할 수 있어요")
                 self.present(alertVC, animated: true)
             }else {
-                let writeVC = WriteVC(type: .post)
-                writeVC.modalPresentationStyle = .fullScreen
-                writeVC.modalTransitionStyle = .coverVertical
-                self.present(writeVC, animated: true) {
-                    writeVC.modalTemplateSelectVC()
+                let writeNC = BaseNC(rootViewController: WriteVC(type: .post))
+                writeNC.isNavigationBarHidden = true
+                writeNC.modalPresentationStyle = .fullScreen
+                writeNC.modalTransitionStyle = .coverVertical
+                self.present(writeNC, animated: true) {
+                    let writeVC = writeNC.viewControllers[0] as? WriteVC
+                    writeVC?.modalTemplateSelectVC()
                 }
             }
             return false // 탭 변경을 막음

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -132,18 +132,20 @@ class WritePickerVC: BaseVC {
     private func postWorryContent(postWorryContent: WorryContentRequestModel) {
         startLoadingAnimation()
         WriteAPI.shared.postWorryContent(param: postWorryContent) { [weak self] result in
-            guard let result = result, let _ = result.data else {
+            guard let result = result, let data = result.data else {
                 self?.presentNetworkAlert()
                 return
             }
             self?.stopLoadingAnimation()
-            if let writeVC = self?.presentingViewController {
+            // TODO: 리스폰스 데이터 worryDetail로 변환해 넘겨주고 updateUI 실행
+            if let writeNC = self?.presentingViewController, let NC = writeNC as? BaseNC {
                 UIView.animate(withDuration: 0.5, animations: {
                     self?.pickerViewLayout.alpha = 0
                 }) { [weak self] _ in
-                    // TODO: 고민 작성 후 해당 고민 상세로 이동
                     self?.dismiss(animated: false) {
-                        writeVC.dismiss(animated: true)
+                        let worryDetailVC = HomeWorryDetailVC(worryId: data.worryId, type: .digging)
+                        NC.setViewControllers([worryDetailVC], animated: true)
+                        NC.popToRootViewController(animated: true)
                     }
                 }
             }

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -145,7 +145,6 @@ class WritePickerVC: BaseVC {
                     self?.dismiss(animated: false) {
                         let worryDetailVC = HomeWorryDetailVC(worryId: data.worryId, type: .digging)
                         NC.setViewControllers([worryDetailVC], animated: true)
-                        NC.popToRootViewController(animated: true)
                     }
                 }
             }


### PR DESCRIPTION
## 💪 작업한 내용
- 기존에 작성탭을 눌렀을때 writeVC 자체를 present 하는 대신 writeVC를 rootVC로 하는 BaseNC를 만들어 navigationController 자체를 present하여 띄워주도록 변경
- 탭바 컨트롤러에서 작성탭에서 writeVC를 루트뷰로 하는 NC를 present하였기 때문에 탭바 -> NC(writeVC) -> pickerVC 구조에서 self인 pickerVC를 present하는 presentingViewController는 NC이다.
- 때문에 writeNC라는 이름으로 self.presentingViewController를 바인딩하고, 이때는 타입이 viewController 이기 때문에 NC라는 이름으로 다시 BaseNC로 타입캐스팅을 해주어 BaseNC 타입의 인스턴스 NC를 구한다.
- 그리고 리스폰스로 받은 데이터를 이용해 worryDetailVC의 인스턴스를 생성하고, NC의 rootVC를 worryDetailVC로 바꾸어 popToRootViewController를 이용해 고민상세 뷰로 화면전환 한다.
- 이를 통해 기존에 띄워지는 고민 작성 뷰를 화면에 노출시키지 않고 바로 고민상세로 가고, 고민상세를 닫을때 바로 기존 탭을 보여질 수 있다.

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 이번 이슈를 처리하는 생각보다 시간이 꽤 걸렸습니다...

기존 구현은 작성탭 클릭시 writeVC에서 부터 각 vc들을 present 방식으로 보여주는데 

홈 -> 고민 작성 -> 데드라인 과 같은 플로우에서 데드라인 창을 dismiss하고  고민 상세를 보여줘야하는데 
이를 구현하기 위해서 처음에 2가지 방법을 생각했는데 
1. 홈 -> 고민 작성 -> 데드라인 -> 데드라인 dismiss -> 고민작성 dismiss -> 홈 -> 고민 상세 present
2.  홈 -> 고민작성 -> 데드라인 -> 데드라인 dismiss -> 고민 상세 present 

1번의 경우 고민 상세에서 창을 닫을 때 바로 홈으로 갈 수 있지만 고민 상세로 가는 과정에서 홈화면이 보여지기 때문에 어색하다는 문제가 있고
2번의 경우 고민상세는 바로 자연스럽게 띄울 수 있는데 고민 상세뷰가 고민 작성 창에서 띄운것이라 고민 상세를 내릴때 고민 작성창이 보인다는 문제가 있었습니다.

| 1번 홈이 보임 | 2번 작성이 보임 |
| ---- | ---- | 
|  ![Simulator Screen Recording - iPhone 13 mini - 2023-12-27 at 16 05 21](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/10998adb-30e4-48f6-a406-6a7360d1a8f7) | ![Simulator Screen Recording - iPhone 13 mini - 2023-12-27 at 15 57 53](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/4843ec3c-2d61-4488-8fb5-6a47be9176a5) |

present 방식이라 플로우 중간의 화면을 바꿔치기 할 수 없어서 transition을 바꿔보고 present 및 dismiss 순서를 조금씩 조정해보면서 자연스럽게 화면전환이 될 수 있도록 1,2번 방식에서 수정해보려 했으나 화면 전환 플로우 상에 홈이나 고민작성이 있기 때문에 1,2번 방식으로는 해결이 어려웠습니다.

- 그래서 결국 화면을 스택처럼 쌓아서 화면전환 시켜주는 NavigationController를 사용해 rootVC를 바꿔주는 방식으로 문제를 해결하였습니다.
  - writeVC 대신 writeVC를 rootVC로 하는 NC자체를 탭바에서 present하고 
  - 고민 완료시 NC에서 setViewControllers를 이용해 NC의 rootVC를 worryDetailVC로 바꾸고 rootVC 즉, 고민 상세로 이동하도록 하였습니다.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
> NavigationController를 사용

![Simulator Screen Recording - iPhone 13 mini - 2023-12-27 at 15 54 50](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/9392629d-5129-47ad-8fe2-7b0efbc3db6f)


## 🚨 관련 이슈
- Resolved: #141


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
