### PR TITLE
[Feat] 빌드별 스키마 설정

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -118,6 +118,10 @@
 		E79AAC4B2A52F3E000F3F439 /* BaseNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AAC492A52F3E000F3F439 /* BaseNC.swift */; };
 		E79AAC5A2A531E3300F3F439 /* NanumMyeongjoOTF.otf in Resources */ = {isa = PBXBuildFile; fileRef = E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */; };
 		E7A3A2822B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A3A2812B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift */; };
+		E7A3A2872B3D8CF2008A03D7 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */; };
+		E7A3A2882B3D8CF4008A03D7 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E7A3A2842B3D7F14008A03D7 /* Debug.xcconfig */; };
+		E7A3A2892B3D8CF6008A03D7 /* QA.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E7A3A2862B3D8C94008A03D7 /* QA.xcconfig */; };
+		E7A3A28A2B3D8CF9008A03D7 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E7A3A2852B3D7F20008A03D7 /* Release.xcconfig */; };
 		E7A94CC42AA484E300F231D0 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A94CC32AA484E300F231D0 /* SignInVC.swift */; };
 		E7A94CC72AA6A46800F231D0 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CC62AA6A46800F231D0 /* KakaoSDKAuth */; };
 		E7A94CC92AA6A46800F231D0 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = E7A94CC82AA6A46800F231D0 /* KakaoSDKCommon */; };
@@ -242,6 +246,9 @@
 		E79AAC492A52F3E000F3F439 /* BaseNC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseNC.swift; sourceTree = "<group>"; };
 		E79AAC592A531E3300F3F439 /* NanumMyeongjoOTF.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumMyeongjoOTF.otf; sourceTree = "<group>"; };
 		E7A3A2812B3ACCCB008A03D7 /* WorryDeadlineUpdateResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorryDeadlineUpdateResponseModel.swift; sourceTree = "<group>"; };
+		E7A3A2842B3D7F14008A03D7 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		E7A3A2852B3D7F20008A03D7 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		E7A3A2862B3D8C94008A03D7 /* QA.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = QA.xcconfig; sourceTree = "<group>"; };
 		E7A94CC12AA4569300F231D0 /* KAERA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KAERA.entitlements; sourceTree = "<group>"; };
 		E7A94CC32AA484E300F231D0 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		E7A94CCC2AAC149900F231D0 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
@@ -575,6 +582,17 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		E7A3A2832B3D7ECB008A03D7 /* Supports */ = {
+			isa = PBXGroup;
+			children = (
+				E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */,
+				E7A3A2842B3D7F14008A03D7 /* Debug.xcconfig */,
+				E7A3A2862B3D8C94008A03D7 /* QA.xcconfig */,
+				E7A3A2852B3D7F20008A03D7 /* Release.xcconfig */,
+			);
+			path = Supports;
+			sourceTree = "<group>";
+		};
 		E7A94CC22AA484C300F231D0 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
@@ -620,7 +638,6 @@
 				E7AC121E2A51CF9D00FE504C /* DataModels */,
 				E7AC121D2A51CF9600FE504C /* Services */,
 				E7AC121C2A51CF8E00FE504C /* APIs */,
-				E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -777,6 +794,7 @@
 		E7C808E72A4D37F800F475CE /* KAERA */ = {
 			isa = PBXGroup;
 			children = (
+				E7A3A2832B3D7ECB008A03D7 /* Supports */,
 				E7A94CC12AA4569300F231D0 /* KAERA.entitlements */,
 				E7AC12162A51CBA400FE504C /* Global */,
 				E78C39F12A5138D200A15120 /* Scenes */,
@@ -878,11 +896,12 @@
 			};
 			buildConfigurationList = E7C808E02A4D37F800F475CE /* Build configuration list for PBXProject "KAERA" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = E7C808DC2A4D37F800F475CE;
 			packageReferences = (
@@ -909,11 +928,15 @@
 			files = (
 				E73A4C162B31234600C019EF /* Settings.bundle in Resources */,
 				E72D6AEB2B1C255F00CF8B01 /* kaera_loading.json in Resources */,
+				E7A3A2872B3D8CF2008A03D7 /* Secrets.xcconfig in Resources */,
 				E7C808F22A4D37FA00F475CE /* Assets.xcassets in Resources */,
 				E7C30F612A533D08002BD782 /* NanumSquareNeoTTF-aLt.ttf in Resources */,
 				E7C30F622A533D08002BD782 /* NanumSquareNeoTTF-bRg.ttf in Resources */,
 				E7C30F632A533D08002BD782 /* NanumSquareNeoTTF-cBd.ttf in Resources */,
+				E7A3A2892B3D8CF6008A03D7 /* QA.xcconfig in Resources */,
+				E7A3A28A2B3D8CF9008A03D7 /* Release.xcconfig in Resources */,
 				E79AAC5A2A531E3300F3F439 /* NanumMyeongjoOTF.otf in Resources */,
+				E7A3A2882B3D8CF4008A03D7 /* Debug.xcconfig in Resources */,
 				E70764EB2AC9980600627AA7 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1037,8 +1060,9 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		E7C808F72A4D37FA00F475CE /* Debug */ = {
+		E7A3A28B2B3D8D52008A03D7 /* QA */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7A3A2862B3D8C94008A03D7 /* QA.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1087,6 +1111,103 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = QA;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = "";
+			};
+			name = QA;
+		};
+		E7A3A28C2B3D8D52008A03D7 /* QA */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7A3A2862B3D8C94008A03D7 /* QA.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = KAERA/KAERA.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 202312271;
+				DEVELOPMENT_TEAM = AFS6YUQ2Y4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = KAERA/Application/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "KAERA-Debug";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.5;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hara.kaera;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = QA;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = QA;
+		};
+		E7C808F72A4D37FA00F475CE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7A3A2842B3D7F14008A03D7 /* Debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1094,11 +1215,13 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
 		E7C808F82A4D37FA00F475CE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7A3A2852B3D7F20008A03D7 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1141,19 +1264,22 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = "";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		E7C808FA2A4D37FA00F475CE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */;
+			baseConfigurationReference = E7A3A2842B3D7F14008A03D7 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1163,6 +1289,7 @@
 				DEVELOPMENT_TEAM = AFS6YUQ2Y4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KAERA/Application/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "KAERA-Debug";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -1184,7 +1311,7 @@
 		};
 		E7C808FB2A4D37FA00F475CE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E70C7C9E2A908574006B2E74 /* Secrets.xcconfig */;
+			baseConfigurationReference = E7A3A2852B3D7F20008A03D7 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1194,6 +1321,7 @@
 				DEVELOPMENT_TEAM = AFS6YUQ2Y4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KAERA/Application/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "KAERA-Debug";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -1207,6 +1335,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1220,19 +1349,21 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E7C808F72A4D37FA00F475CE /* Debug */,
+				E7A3A28B2B3D8D52008A03D7 /* QA */,
 				E7C808F82A4D37FA00F475CE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		E7C808F92A4D37FA00F475CE /* Build configuration list for PBXNativeTarget "KAERA" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E7C808FA2A4D37FA00F475CE /* Debug */,
+				E7A3A28C2B3D8D52008A03D7 /* QA */,
 				E7C808FB2A4D37FA00F475CE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-Debug.xcscheme
+++ b/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-Debug.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+               BuildableName = "KAERA.app"
+               BlueprintName = "KAERA"
+               ReferencedContainer = "container:KAERA.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-QA.xcscheme
+++ b/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-QA.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+               BuildableName = "KAERA.app"
+               BlueprintName = "KAERA"
+               ReferencedContainer = "container:KAERA.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "QA"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "QA"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "QA"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "QA">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "QA"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-Release.xcscheme
+++ b/KAERA/KAERA.xcodeproj/xcshareddata/xcschemes/KAERA-Release.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+               BuildableName = "KAERA.app"
+               BlueprintName = "KAERA"
+               ReferencedContainer = "container:KAERA.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E7C808E42A4D37F800F475CE"
+            BuildableName = "KAERA.app"
+            BlueprintName = "KAERA"
+            ReferencedContainer = "container:KAERA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## 💪 작업한 내용
- 기존 Secretes.xcconfig 파일에서 관리하는 데이터를 각 스키마별 xcconfig 파일을 만들어 파일 내에 import하여 사용
  - 각 xcconfig별 APP_NAME과 BASE_URL을 분리
  - Supports 그룹을 추가하고 거기에 모든 xcconfig파일들을 관리
  - 빌드 목적에 따라 각 설정을 구분할 수 있도록 QA,Debug,Release 3가지 스키마를 추가

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
🚨 🚨 xcconfig 설정파일들은 gitignore되어 pull 받을 수 없습니다. 노션에 폴더를 첨부할테니 다운 받아 프로젝트내 Kaera폴더 내에 아래 스크린샷 처럼 넣어주세요. 🚨🚨

- 보통 프로젝트에서 개발용/릴리즈용 서버를 따로 구분하여 작업하며, 빌드 환경별로 세팅이 달라집니다.
- 이런 개발 환경별로 매번 서버 URL주소를 바꾼다든가 일일이 설정을 바꿀 수는 없기에 빌드 환경을 구분할 수 있도록 Build Scheme을 나누어 빌드 환경을 구분해 줍니다.
- 사실 캐라 프로젝트가 규모가 작아 굳이 이렇게 구분해야 하나 잘 모르겠습니다만 배포용/ 개발용 API는 구분 예정이기 때문에 어차피 세팅이 필요할 것 같아 스키마를 나눠주었습니다.
- 스키마별로 빌드시 앱 이름이 다르게 적용됩니다. (앱 아이콘도 다르게 할 수 있어요)
- 전처리문을 통해 빌드 환경별로 코드 상에 분기처리가 가능합니다.
```C
#if DEBUG {
// 디버그 빌드 시 설정
} #elseif QA {
// QA 빌드 시 설정
} #elseif RELEASE {
// 릴리즈 빌드 시 설정
}
```

아래 자료들을 참고 했습니다.
[Xcode - Target, Project, Scheme, Build setting 에 대해 ](https://zzoo789.tistory.com/entry/iOS-Xcode-Target-Project-Scheme-Build-setting-%EC%97%90-%EB%8C%80%ED%95%98%EC%97%AC)
[Build Scheme 나누는 방법 (debug, release)](https://ios-development.tistory.com/934)
[프로젝트 배포 환경별 Build Scheme 세팅(.xcconfig 사용) + key 숨기기](https://gyuios.tistory.com/240)
[Scheme으로 Debug / Release 프로젝트 빌드 구분 설정하기](https://green1229.tistory.com/212)

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="213" alt="image" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/ca0eeefd-1690-4ed9-a592-09997231cbf7">


## 🚨 관련 이슈
- Resolved: #125


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
