### PR TITLE
[Fix] 토큰 갱신 interceptor retry 버그 수정

### DIFF
--- a/KAERA/KAERA/Network/Base/AuthInterceptor.swift
+++ b/KAERA/KAERA/Network/Base/AuthInterceptor.swift
@@ -19,7 +19,7 @@ final class AuthInterceptor: RequestInterceptor {
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         print("retry 진입")
         guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401, let pathComponents = request.request?.url?.pathComponents,
-              !pathComponents.contains("getNewToken")
+              !pathComponents.contains("refresh")
         else {
             dump(error)
             completion(.doNotRetryWithError(error))
@@ -35,6 +35,5 @@ final class AuthInterceptor: RequestInterceptor {
             KeychainManager.save(key: .accessToken, value: renewedAccessToken)
             completion(.retry)
         }
-        
     }
 }

--- a/KAERA/KAERA/Network/Base/BaseTargetType.swift
+++ b/KAERA/KAERA/Network/Base/BaseTargetType.swift
@@ -12,7 +12,9 @@ protocol BaseTargetType: TargetType { }
 
 extension BaseTargetType {
     var baseURL: URL {
-        return URL(string: APIConstant.baseURL)!
+        guard let baseURL = URL(string: APIConstant.baseURL) else {
+            fatalError("APIConstant.baseURL Not Configured")
+        }
+        return baseURL
     }
-
 }


### PR DESCRIPTION
## 💪 작업한 내용
- 토큰이 만료된 각 API 요청에 대해 retry 메서드 호출이 되는데 이때 postRenewalRequest를 통해 토큰을 갱신하고 기존에 API 요청을 다시 시도한다.
- postRenewalRequest 요청 자체에서 401 토큰 만료 응답이 오면 renewal -> retry -> renewal 의 반복 요청으로 요청 에러가 발생한다.
- 따라서 retry 메서드 실행시 guard 조건 문에서 retry가 발동된 API 이름에 "refresh" 가 있으면 다시 요청을 시도 하지 않고 메서드를 종료하도록 수정

- 강제 언래핑 사용대신 guard let 구문으로 대체하고 nil일 경우 fatalError를 내도록 수정

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 다른 작업 중 splash에서 자꾸 에러가 나서 원인을 찾아보니 가지고 있던 토큰이 모두 만료되어 splashVC에서 처음 postRenewalRequest 요청시 401 응답이 와서 retry가 실행되고 이를 통해 또 postRenewalRequest요청이 가는 반복으로 에러가 발생한다는 것을 알게 되었습니다...

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #166 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
