### PR TITLE
[Fix] 카카오톡 미설치 된 기기 로그인 시 웹 로그인 실행

### DIFF
--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -46,16 +46,24 @@ final class SignInViewModel: NSObject, ViewModelType {
         /// 카카오톡 실행 가능한지 확인
         if UserApi.isKakaoTalkLoginAvailable() {
             /// 카카오톡 로그인 실행
-            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+            UserApi.shared.loginWithKakaoTalk {[weak self](oauthToken, error) in
                 if error != nil {
+                    self?.output.send(false)
                 } else {
                     print("loginWithKakaoTalk() success.")
-                    self.postKakaoLogin(token: oauthToken?.accessToken ?? "")
+                    self?.postKakaoLogin(token: oauthToken?.accessToken ?? "")
                 }
             }
             
         } else {
-            output.send(false)
+            UserApi.shared.loginWithKakaoAccount { [weak self] (oauthToken, error) in
+                if error != nil {
+                    self?.output.send(false)
+                } else {
+                    print("loginWithKakaoAccount() success.")
+                    self?.postKakaoLogin(token: oauthToken?.accessToken ?? "")
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## 💪 작업한 내용
- 카카오톡 미설치 경우 웹페이지를 통해 카카오 로그인을 수행 할 수 있도록 loginWithKakaoAccount를 실행
- 메서드 실행시 사파리로 카카오 로그인 페이지가 열려 카카오 계정으로 로그인 가능
- 카카오 로그인 기록이 있으면 카카오 로그인 과정 없이 바로 로그인 가능

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 핸드폰에는 카톡이 당연히 깔려 있고 시뮬레이터에서는 애플로그인으로만 테스트해서 카카오톡 미설치 상황에서 카톡 로그인 생각을 아예 못하고 있다가 지금 깨달아 바로 수정하였습니다..


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2024-01-01 at 00 14 37](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/72b77711-7cd1-450b-b8c4-fde946a5c96a)


## 🚨 관련 이슈
- Resolved: #169 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
