### PR TITLE
[Fix] 고민 길이 길때 답변 색상 달라지는 오류 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -184,7 +184,7 @@ final class HomeWorryDetailVC: BaseVC {
         worryDetailTV.register(HomeWorryDetailFooterView.self, forHeaderFooterViewReuseIdentifier: HomeWorryDetailFooterView.className)
         /// estimated 높이를 설정해줘야 contentSize에 반영이 됨
         worryDetailTV.estimatedSectionHeaderHeight = 200
-        worryDetailTV.estimatedRowHeight = 200
+        worryDetailTV.estimatedRowHeight = 1000
         worryDetailTV.estimatedSectionFooterHeight = 200
         worryDetailTV.backgroundView = backgroundImageView
     }
@@ -235,13 +235,13 @@ final class HomeWorryDetailVC: BaseVC {
         switch pageType {
         case .digging:
             updateDeadline(deadline: worryDetail.dDay)
-
+            
         case .dug:
             navigationBarView.setTitleText(text: "나의 고민")
-                self.finalAnswer = worryDetail.finalAnswer
-                self.reviewText = worryDetail.review.content
-                reviewView.setReviewText(content: worryDetail.review.content)
-                reviewView.setUpdatedDate(updatedAt: worryDetail.review.updatedAt)
+            self.finalAnswer = worryDetail.finalAnswer
+            self.reviewText = worryDetail.review.content
+            reviewView.setReviewText(content: worryDetail.review.content)
+            reviewView.setUpdatedDate(updatedAt: worryDetail.review.updatedAt)
         }
         
         /// 갱신된 데이터로 테이블뷰 정보를 갱신


### PR DESCRIPTION
## 💪 작업한 내용
- 고민 길이가 길어질 때 답변칸(TableViewFooterView) 의 색상만 달라지는 오류를 수정했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 해결했지만,,,찜찜합니다 ㅠ
 /// estimated 높이를 설정해줘야 contentSize에 반영이 됨
        worryDetailTV.estimatedSectionHeaderHeight = 200
        worryDetailTV.estimatedRowHeight = 200
        worryDetailTV.estimatedSectionFooterHeight = 200
        
@daminoworld 요 부분에서 200으로 값이 정해져 있는게 이상해서 UITableView.automaticDimension도 넣어보고 값을 늘려도 보고 했는데, rowHeight 값을 늘렷더니 글자 잘림 없이 잘 나오는 것을 확인했습니다. 

일단 1000으로 크게 늘려놓긴 했는데, 더 길어지면 이것도 아마 문제가 발생하거 같긴합니다🥲 일단은 해결!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/85a31a8e-e2bf-4945-8db1-fe5192fe03e9 " width="400"/>


## 🚨 관련 이슈
- Resolved: #176 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
