### PR TITLE
[Chore] 고민 상세 뷰 데이터 전달 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/Model/WorryContentResponseModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/Model/WorryContentResponseModel.swift
@@ -11,7 +11,7 @@ struct WorryContentResponseModel: Codable {
     let worryId: Int
     let title: String
     let templateId: Int
-    let answers: [String]
+    let answers, subtitles: [String]
     let createdAt: String
     let deadline: String
     let dDay: Int

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -81,6 +81,7 @@ final class HomeWorryDetailVC: BaseVC {
 
         if let worryDetailData = worryDetail {
             updateUI(worryDetail: worryDetailData)
+            worryDetailViewModel.worryDetail = worryDetailData
         } else {
             self.startLoadingAnimation()
             input.send(worryId)

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -73,13 +73,18 @@ final class HomeWorryDetailVC: BaseVC {
     private var isReviewEditing: Bool = false
     
     // MARK: - Initialization
-    init(worryId: Int, type: PageType) {
+    init(worryId: Int, type: PageType, worryDetail: WorryDetailModel? = nil) {
         super.init(nibName: nil, bundle: nil)
         self.pageType = type
         self.worryId = worryId
         dataBind()
-        self.startLoadingAnimation()
-        input.send(worryId)
+
+        if let worryDetailData = worryDetail {
+            updateUI(worryDetail: worryDetailData)
+        } else {
+            self.startLoadingAnimation()
+            input.send(worryId)
+        }
     }
     
     required init?(coder: NSCoder) {

--- a/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
+++ b/KAERA/KAERA/Scenes/Writing/View/WritePickerVC.swift
@@ -137,13 +137,16 @@ class WritePickerVC: BaseVC {
                 return
             }
             self?.stopLoadingAnimation()
-            // TODO: 리스폰스 데이터 worryDetail로 변환해 넘겨주고 updateUI 실행
+            
             if let writeNC = self?.presentingViewController, let NC = writeNC as? BaseNC {
                 UIView.animate(withDuration: 0.5, animations: {
                     self?.pickerViewLayout.alpha = 0
                 }) { [weak self] _ in
                     self?.dismiss(animated: false) {
-                        let worryDetailVC = HomeWorryDetailVC(worryId: data.worryId, type: .digging)
+                        
+                        let worryDetailModel = WorryDetailModel(title: data.title, templateId: data.templateId, subtitles: data.subtitles , answers: data.answers, period: "", updatedAt: data.createdAt, deadline: data.deadline, dDay: data.dDay, finalAnswer: "", review: Review(content: "", updatedAt: ""))
+                        
+                        let worryDetailVC = HomeWorryDetailVC(worryId: data.worryId, type: .digging, worryDetail: worryDetailModel)
                         NC.setViewControllers([worryDetailVC], animated: true)
                     }
                 }


### PR DESCRIPTION
## 💪 작업한 내용
- worryDetailModel에 subtitle 추가함
- worryDetailVC에 worryDetailModel의 옵셔널 타입을 detailVC에 init 파라미터로 추가하고 파라미터 디폴트 값을 nil로 설정해 다른 파일에서 수정이 필요없도록 함 init 내부 if let 바인딩을 통해 nil이 아니면 worryDetailModel 데이터를 넘겨 updateUI를 실행하고 nil이면 기존처럼 input.send를 통해 데이터 요청 수행
- WorryDecisionVC에서 postWorryContent 리스폰스로 받은 데이터를 worryDetailVC init을 통해 넘겨줌
- 고민 수정시 worryDetail VM에서 worryDetail을 정보를 가져오는데 고민 작성 직후 상세에는 VM에서 worryDetail 데이터를 가지고 있지 않기 때문에 VM에 worryDetailModel 데이터 추가

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 고민 작성 직후 고민상세 띄울때 고민 상세 조회 API 요청을 하지 않고 고민 작성 완료 리스폰스 데이터를 통해 WorryDetailModel 데이터를 worryDetailVC의 init 을 통해 넘겨서 데이터 통신 없이 고민상세 띄움

## 🚨 관련 이슈
- Resolved: #178 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
