### PR TITLE
[Feat] 고민 캐기 후 완료된 고민 상세로 이동 구현

### DIFF
--- a/KAERA/KAERA/Scenes/Home/View/HomeVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeVC.swift
@@ -62,6 +62,20 @@ final class HomeVC: BaseVC {
             pageVC.setViewControllers([firstVC], direction: .forward, animated: true)
         }
     }
+    
+    func presentDugWorryDetail(worryId: Int) {
+        pageVC.setViewControllers([contents[1]], direction: .forward, animated: true)
+        headerLabel.text = "그동안 캐낸 보석들 ✨"
+        pageIcn.image = UIImage(named: "icn_dug_page")
+        headerBGView.snp.updateConstraints {
+            $0.width.equalTo(176.adjustedW)
+        }
+        let dugDetailVC = HomeWorryDetailVC(worryId: worryId, type: .dug)
+        dugDetailVC.modalTransitionStyle = .coverVertical
+        dugDetailVC.modalPresentationStyle = .fullScreen
+        self.present(dugDetailVC, animated: true)
+    }
+    
 }
 
 extension HomeVC: UIPageViewControllerDelegate {

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/WorryDecisionVC.swift
@@ -144,11 +144,22 @@ final class WorryDecisionVC: BaseVC {
             })
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
-            if let worryDetailVC = self.presentingViewController {
+            self.presnetToDugWorryDetail()
+        }
+    }
+    
+    private func presnetToDugWorryDetail() {
+        if let digDetailVC = self.presentingViewController, let tabBar = digDetailVC.presentingViewController as? KaeraTabbarController {
+            if let homeTab = tabBar.viewControllers?[0] as? BaseNC {
                 self.dismiss(animated: true) {
-                    worryDetailVC.dismiss(animated: true)
+                    digDetailVC.dismiss(animated: true) {
+                        if let homeVC = homeTab.viewControllers[0] as? HomeVC {
+                            homeVC.presentDugWorryDetail(worryId: self.worryId)
+                        }
+                    }
                 }
             }
+            
         }
     }
     


### PR DESCRIPTION
## 💪 작업한 내용
- 고민캐기가 이루어지는 worryDecisionVC부터 presentingViewController를 이용해 홈탭의 homeVC까지 바인딩
- 고민중 상세 페이지를 dismiss 후 바인딩 한 homeVC에서 고민완료 상세 페이지를 띄우도록 메서드 실행
- HomeVC에서 pageVC로 2번째 고민 캐기 화면으로 전환시키고 캔 고민의 worryId로 고민 완료 상세 페이지를 present 해줌


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
-  고민 캐기를 했을때 화면 구조가 SplashVC - KaeraTabBarController(BaseNC(rootVC: HomeVC)) - WorryDetailVC - WorryDecisionVC 인데 고민 완료 화면을 보여주기 위해서는 WorryDetailVC과, WorryDecisionVC를 내리고 완료된 고민 상세를 띄워줘야했습니다.
- 처음에는 BaseNC를 찾아서 완료 WorryDetailVC를 push해줬었는데 (BaseNC(HomeVC - WorryDetailVC)) 
- 이때 x버튼으로 고민 상세를 dismiss시 BaseNC가 통째로 사라져 바로 SplashVC로 가는 문제가 있었고 그렇다고 worryDetail의 x 버튼을 눌렀을때 homeVC로 pop시켜주도록 하려면 또 추가적인 분기처리 코드등 리소스가 들어가서
- BaseNC의 rootVC인 homeVC를 찾아서 homeVC의 내부에 worryDetailVC를 present해주는 메서드를 따로 구현해서 실행시켜 주는것으로 구현하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 그냥 BaseNC에서 push했을 때  |  수정된 현재 버전 |
| ------- | -------- |
| ![Simulator Screen Recording - iPhone 13 mini - 2024-01-10 at 00 07 03](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/34b5d34e-36e8-4b50-b3bf-2d1f5ec29865) |  ![Simulator Screen Recording - iPhone 13 mini - 2024-01-09 at 23 58 49](https://github.com/TeamHARA/KAERA_iOS/assets/32871014/f4d81869-ee39-4dce-8ae4-31ebbbc1a870) |

## 🚨 관련 이슈
- Resolved: #183 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
