### PR TITLE
[Fix] retry로 토큰 갱신시 요청 헤더 미 갱신 이슈 수정

### DIFF
--- a/KAERA/KAERA/Application/AppDelegate.swift
+++ b/KAERA/KAERA/Application/AppDelegate.swift
@@ -95,8 +95,6 @@ extension AppDelegate: MessagingDelegate {
     
     /// 토큰 갱신 모니터링 메서드
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print("Firebase registration token: \(String(describing: fcmToken))")
-        
         if let fcmToken {
             print("Saved FCM Token: \(fcmToken)")
             /// 키체인에 FCM Token 저장

--- a/KAERA/KAERA/Network/Base/AuthInterceptor.swift
+++ b/KAERA/KAERA/Network/Base/AuthInterceptor.swift
@@ -15,9 +15,15 @@ final class AuthInterceptor: RequestInterceptor {
     
     private init() {}
 
+    private let retryLimit = 5
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         print("retry 진입")
+        if request.retryCount > retryLimit {
+            print("Over retry limit")
+            completion(.doNotRetryWithError(error))
+            return
+        }
         guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401, let pathComponents = request.request?.url?.pathComponents,
               !pathComponents.contains("refresh")
         else {

--- a/KAERA/KAERA/Network/Base/AuthInterceptor.swift
+++ b/KAERA/KAERA/Network/Base/AuthInterceptor.swift
@@ -16,6 +16,20 @@ final class AuthInterceptor: RequestInterceptor {
     private init() {}
 
     private let retryLimit = 5
+    private var hasAccessTokenRenewed = false
+    
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        if hasAccessTokenRenewed {
+            var renewedUrlRequest = urlRequest
+            if let accessToken = KeychainManager.load(key: .accessToken) {
+                renewedUrlRequest.setValue(accessToken, forHTTPHeaderField: "Authorization")
+                hasAccessTokenRenewed = false
+                completion(.success(renewedUrlRequest))
+                return
+            }
+        }
+        completion(.success(urlRequest))
+    }
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         print("retry 진입")
@@ -31,7 +45,7 @@ final class AuthInterceptor: RequestInterceptor {
             completion(.doNotRetryWithError(error))
             return
         }
-        AuthAPI.shared.postRenewalRequest { res in
+        AuthAPI.shared.postRenewalRequest { [weak self] res in
             guard let res, let data = res.data else {
                 //TODO: 재갱신 실패시 Refresh Token까지 만료된 것이라 처리 필요
                 completion(.doNotRetryWithError(error))
@@ -39,6 +53,7 @@ final class AuthInterceptor: RequestInterceptor {
             }
             let renewedAccessToken = data.accessToken
             KeychainManager.save(key: .accessToken, value: renewedAccessToken)
+            self?.hasAccessTokenRenewed = true
             completion(.retry)
         }
     }

--- a/KAERA/KAERA/Network/Base/NetworkConstant.swift
+++ b/KAERA/KAERA/Network/Base/NetworkConstant.swift
@@ -10,9 +10,12 @@ import Foundation
 struct NetworkConstant {
     
     static let noTokenHeader = ["Content-Type": "application/json"]
-    
-    static let hasTokenHeader = ["Content-Type": "application/json",
-                                 "Authorization": NetworkConstant.accessToken]
+        
+    static var hasTokenHeader: [String: String] {
+        get {
+           return ["Content-Type": "application/json", "Authorization": NetworkConstant.accessToken]
+        }
+    }
     
     /// 임시로 현재 고정  bearerToken 직접 사용
     static let bearerToken = {
@@ -22,10 +25,12 @@ struct NetworkConstant {
         return token
     }()
     
-    static let accessToken = {
-        guard let accessToken = KeychainManager.load(key: .accessToken) else {  fatalError("AccessToken Not in the Keychain")
+    static var accessToken: String {
+        get {
+            guard let accessToken = KeychainManager.load(key: .accessToken) else {  fatalError("AccessToken Not in the Keychain")
+            }
+            return accessToken
         }
-        return accessToken
-    }()
+    }
     
 }


### PR DESCRIPTION
## 💪 작업한 내용
- 기존 NetorkConstant의 static let으로 헤더 값을 사용했는데, let으로 되어있기 때문에 키체인에서 가져오는 accessToken 정보가 바뀌어도 처음 실행시 let으로 저장됨 값에서 바뀌지 않는 문제가 있었음
- static var 로 제한자를 수정하고 getter만 지정해서 accessToken 값을 키체인에서 가져오도록 수정

- retryLimit을 5로 정해고 retryCount를 이용해 retry 횟수 제한 - 횟수 초과시 doNotRetryWithError
- retry에 진입해 토큰 갱신 API를 통해 토큰을 갱신해도 기존 만료된 엑세스 토큰을 가진 요청의 헤더의  엑세스 토큰은 바뀌지 않아 다시 retry로 계속 진입하게 되는 문제가 있었음
- 그래서 hasAccessTokenRenewed 플래그를 두고 토큰이 갱신되었을 때 API 요청 직전에 실행되는 adapt 메서드를 구현해 기존 요청의 헤더 값을 갱신된 엑세스 토큰으로 수정해주고 다시 요청을 수행하도록 함

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 원래 폰으로 테스트했을 때 가끔 무한 로딩에 걸려서 데이터 갱신이 제대로 안되는 문제가 있었는데(앱을 껐다 켜야만 해결됨) 그래서 retry 쪽에 문제가 있다는 것만 짐작하고 있다가
- 이전 PR을 이슈를 해결하다가 시뮬레이터에서 엑세스 토큰이 만료가 되어 무한 retry 반복하는 이슈가 있는 걸 실시간으로 확인해서 해당 요청에 사용된 "만료된 토큰"을 따로 저장해서 테스트 해보며 이슈를 처리할 수 있었습니다.
- 디버깅을 통해 파악된 원인은 retry에서 토큰이 갱신 되어도 completion(.retry)로 기존 API 요청이 다시 수행되었을때 헤더의 엑세스 토큰이 갱신되지 않은 토큰이였다는 것입니다.
- 그래서 우선 NetworkConstant의 전역 상수로 가져오게 되었을때 상수이기 때문에 그 값이 이후로 다른 요청을해도 accessToken을 다시 load하지 않는아 토큰이 바뀌지 않는 문제가 있어 이를 수정하기 위해 static var로 바꾸고 getter를 통해 값을 가져올 수 있도록 했습니다.
- 그런데 이렇게 해도 completion(.retry) 에서 기존 API 요청의 헤더 값을 다시 가져오지 않기 때문에 근본적인 문제 해결이 안되었습니다.
- retry 메서드에서 request 파라미터에서 헤더값을 수정하려고 해봤지만 retry 메서드의 request.urlRequest는 get-only기 때문에 수정을 할수가 없었습니다.
- 그리하여 API 요청 직전에 호출되는 adapt 함수를 구현하여 갱신된 토큰을 통해 요청 헤더를 갱신할 수 있도록 하였습니다.
이렇게 까지는 했는데 계속 헤더가 바뀌지 않는 문제가 발생....삽질 하다가 보니까
```swift
func adapt {
  if 토큰 갱신{
    ...
    /// 갱신 토큰 헤더를 가진 새요청
    completion(.success(newRequest))
  }
  completion(.success(oldRequest))
}
```
위와 같은 로직에서 newRequest가 completion으로 넘겨지고 if문이 끝나고 oldRequest가 다시 넘겨져 바뀌지 않은 것으로 계속 요청이 수행되었던것!!! 결국 if문 안에 return을 추가해주니 문제가 해결되었습니다....하... 앞부분도 오래걸렸지만 마지막 삽질까지 반나절 걸렸어용...

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 문제 발생 로그 |
| ---- |
| 만료된 토큰으로 요청 (끝자리 7E4) |
| <img width="907" alt="1" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/db7c4c85-e21b-4888-a477-c865e1c339a5"> |
| 토큰 권한 만료로 retry 내 갱신 API 요청 진입 |
| <img width="507" alt="2" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/1065771a-7f23-4d4c-890e-dbc3fbf0728d"> |
| 토큰 갱신 API로 토큰 재발급 완료 |
| <img width="1154" alt="3" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/1264b64e-97e3-4e83-8449-99a003fa3806"> |
| 키체인에 새 토큰 저장 |
| <img width="589" alt="4" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/0845f7e6-5520-49ab-a915-16a4c850a5bb"> |
| 그러나 헤더에 기존과 같은 토큰으로 요청 수행됨 |
| <img width="934" alt="5" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/1caa6018-09ed-4882-99c7-4025d8f9b68c"> |


## 🚨 관련 이슈
- Resolved: #184 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
