### PR TITLE
[Chore] 애플 로그인 요청 정보 이메일 제외 

### DIFF
--- a/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/SignInViewModel.swift
@@ -70,7 +70,7 @@ final class SignInViewModel: NSObject, ViewModelType {
     private func checkAppleLogin() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
+        request.requestedScopes = [.fullName]
         
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self


### PR DESCRIPTION
## 💪 작업한 내용
- 애플 로그인 시 요청하는 정보의 범위에서 이메일 제외 (따로 이메일 정보를 사용하지 않기 때문에 삭제)

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/460bf820-b4f2-49d2-b471-a4b30229ace4" width="300">

## 🚨 관련 이슈
- Resolved: #192


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
