### PR TITLE
[Chore] MoyaProvider의 세션의 configuration 설정

### DIFF
--- a/KAERA/KAERA.xcodeproj/project.pbxproj
+++ b/KAERA/KAERA.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		E70764EB2AC9980600627AA7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70764EA2AC9980600627AA7 /* GoogleService-Info.plist */; };
 		E70C7CA12A90959A006B2E74 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA02A90959A006B2E74 /* HomeService.swift */; };
 		E70C7CA32A909829006B2E74 /* HomeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C7CA22A909829006B2E74 /* HomeAPI.swift */; };
+		E719C10D2B5D584600FED2EB /* MoyaSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E719C10C2B5D584600FED2EB /* MoyaSession.swift */; };
 		E71FC2262AD284D9001DD27D /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71FC2252AD284D9001DD27D /* SplashVC.swift */; };
 		E71FC22C2AD29400001DD27D /* RenewalTokenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71FC22B2AD29400001DD27D /* RenewalTokenModel.swift */; };
 		E71FC2442ADC01B6001DD27D /* MyPageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71FC2432ADC01B6001DD27D /* MyPageVC.swift */; };
@@ -203,6 +204,7 @@
 		E70BB9062B48F38A005CBE6B /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		E70C7CA02A90959A006B2E74 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		E70C7CA22A909829006B2E74 /* HomeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPI.swift; sourceTree = "<group>"; };
+		E719C10C2B5D584600FED2EB /* MoyaSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaSession.swift; sourceTree = "<group>"; };
 		E71FC2252AD284D9001DD27D /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
 		E71FC22B2AD29400001DD27D /* RenewalTokenModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewalTokenModel.swift; sourceTree = "<group>"; };
 		E71FC2432ADC01B6001DD27D /* MyPageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageVC.swift; sourceTree = "<group>"; };
@@ -699,6 +701,7 @@
 				E79AAC422A52F36500F3F439 /* NetworkResult.swift */,
 				E7AC12202A51CFFD00FE504C /* GeneralResponse.swift */,
 				E7B0912F2B0DF6AA00F47BEB /* AuthInterceptor.swift */,
+				E719C10C2B5D584600FED2EB /* MoyaSession.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1009,6 +1012,7 @@
 				E79AAC302A52F2C300F3F439 /* String+.swift in Sources */,
 				E72D6AF32B1C907800CF8B01 /* EditWorryResponseModel.swift in Sources */,
 				85A849312A87A9F7009F1468 /* TemplateContentTVC.swift in Sources */,
+				E719C10D2B5D584600FED2EB /* MoyaSession.swift in Sources */,
 				85ECEE492A9A406B00A624AE /* ArchiveService.swift in Sources */,
 				E7F8CC642B10712600066BB1 /* OnboardingVC.swift in Sources */,
 				E79AAC4B2A52F3E000F3F439 /* BaseNC.swift in Sources */,

--- a/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
+++ b/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
@@ -11,7 +11,7 @@ import Moya
 final class ArchiveAPI {
     
     static let shared: ArchiveAPI = ArchiveAPI()
-    private let archiveProvider = MoyaProvider<ArchiveService>(session: Session(interceptor: AuthInterceptor.shared),plugins: [MoyaLoggingPlugin()])
+    private let archiveProvider = MoyaProvider<ArchiveService>(session: MoyaSession.shared.session,plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/AuthAPI.swift
+++ b/KAERA/KAERA/Network/APIs/AuthAPI.swift
@@ -11,7 +11,7 @@ import Moya
 final class AuthAPI {
     
     static let shared: AuthAPI = AuthAPI()
-    private let authProvider = MoyaProvider<AuthService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
+    private let authProvider = MoyaProvider<AuthService>(session: MoyaSession.shared.session, plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -50,7 +50,6 @@ final class HomeAPI {
         homeProvider.request(.worryDetail(worryId: param)) { response in
             switch response {
             case .success(let result):
-                /// do-catch문 안쓸시에 타입형 안맞는 오류 발생
                 do {
                     let worryDetailResponse = try result.map(GeneralResponse<WorryDetailModel>.self)
                     completion(.success(worryDetailResponse))

--- a/KAERA/KAERA/Network/APIs/HomeAPI.swift
+++ b/KAERA/KAERA/Network/APIs/HomeAPI.swift
@@ -12,7 +12,7 @@ final class HomeAPI {
     
     static let shared: HomeAPI = HomeAPI()
 
-    private let homeProvider = MoyaProvider<HomeService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
+    private let homeProvider = MoyaProvider<HomeService>(session: MoyaSession.shared.session, plugins: [MoyaLoggingPlugin()])
     
     private init() { }
     

--- a/KAERA/KAERA/Network/APIs/WriteAPI.swift
+++ b/KAERA/KAERA/Network/APIs/WriteAPI.swift
@@ -12,7 +12,7 @@ import Moya
 final class WriteAPI {
     
     static let shared: WriteAPI = WriteAPI()
-    private let writeProvider = MoyaProvider<WriteService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
+    private let writeProvider = MoyaProvider<WriteService>(session: MoyaSession.shared.session, plugins: [MoyaLoggingPlugin()])
 
     private init() { }
     

--- a/KAERA/KAERA/Network/Base/MoyaSession.swift
+++ b/KAERA/KAERA/Network/Base/MoyaSession.swift
@@ -1,0 +1,23 @@
+//
+//  MoyaSession.swift
+//  KAERA
+//
+//  Created by 김담인 on 2024/01/21.
+//
+
+import Foundation
+import Moya
+
+final class MoyaSession {
+    
+    let session: Session = {
+        let configuration = URLSessionConfiguration.af.default
+        configuration.timeoutIntervalForRequest = 5
+        let interceptor = AuthInterceptor.shared
+        return Session(configuration: configuration, interceptor: interceptor)
+    }()
+    
+    static let shared = MoyaSession()
+    
+    private init() { }
+}

--- a/KAERA/KAERA/Network/Base/MoyaSession.swift
+++ b/KAERA/KAERA/Network/Base/MoyaSession.swift
@@ -12,7 +12,7 @@ final class MoyaSession {
     
     let session: Session = {
         let configuration = URLSessionConfiguration.af.default
-        configuration.timeoutIntervalForRequest = 5
+        configuration.timeoutIntervalForRequest = 3
         let interceptor = AuthInterceptor.shared
         return Session(configuration: configuration, interceptor: interceptor)
     }()


### PR DESCRIPTION
## 💪 작업한 내용
- URlsessionConfiguration타입 프로퍼티 생성 후 configuratioin의 timeoutIntervalForRequest를 5로 설정하여 요청 대기 시간을 5초로 설정
- AuthInterceptor로 Session의 interceptor로 설정
- 각 API의 moyaProvider 세션을 MoyaSession 클래스로 설정


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기본으로 설정되어 있는 요청 대기 시간 10초는 길어서 5초로 설정하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #195 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
