### PR TITLE
[Feat] 고민보관함 네트워크/인앱 에러뷰 적용

### DIFF
--- a/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
+++ b/KAERA/KAERA/Network/APIs/ArchiveAPI.swift
@@ -17,9 +17,8 @@ final class ArchiveAPI {
     
     public private(set) var archiveWorryListResponse: GeneralResponse<WorryListModel>?
     
-    
     // MARK: - HomeGemList
-    func getArchiveWorryList(param: Int, completion: @escaping (GeneralResponse<WorryListModel>?) -> () ) {
+    func getArchiveWorryList(param: Int, completion: @escaping (Result<GeneralResponse<WorryListModel>, ErrorCase>) -> Void ) {
         archiveProvider.request(.archiveWorryList(templateId: param)) { [weak self] response in
             switch response {
             case .success(let result):
@@ -27,14 +26,19 @@ final class ArchiveAPI {
                     self?.archiveWorryListResponse = try
                     result.map(GeneralResponse<WorryListModel>?.self)
                     guard let worryList = self?.archiveWorryListResponse else { return }
-                    completion(worryList)
+                    completion(.success(worryList))
                 } catch(let err) {
                     print(err.localizedDescription)
-                    completion(nil)
+                    completion(.failure(.appError))
                 }
             case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil)
+                if let response = err.response {
+                    /// HTTP 상태 코드가 400-500 사이인 경우 appError로 처리
+                    completion(.failure((400...500).contains(response.statusCode) ? .appError : .internetError))
+                } else {
+                    /// 응답이 없는 경우 internetError로 처리
+                    completion(.failure(.internetError))
+                }
             }
         }
     }

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -134,8 +134,6 @@ class ArchiveVC: BaseVC, RefreshListDelegate {
 
     private func reloadWorryDetail() {
         self.errorView.isHidden = true
-        /// 구독을 취소하고 다시 구독을 시행한다
-        /// cancellables.removeAll()과 동일한 역할을 하지만 새롭게 선언하는 것이 시간복잡도 측면에서 더 효과적이다.
         cancellables = []
         dataBind()
         self.startLoadingAnimation()
@@ -146,8 +144,7 @@ class ArchiveVC: BaseVC, RefreshListDelegate {
         self.view.addSubView(errorView)
         
         errorView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
-            $0.verticalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.edges.equalTo(view.safeAreaLayoutGuide).inset(16)
         }
     }
     

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -9,46 +9,50 @@ import UIKit
 import Combine
 
 // 뷰 모델로써 데이터의 상태를 가지고 있음
-class WorryListViewModel: ViewModelType {
+final class WorryListViewModel: ViewModelType {
     
     // MARK: - Properties
     private var IdtoImgDict: [Int: String] = [1: "gem_blue_m", 2: "gem_red_m", 3: "gem_orange_m", 4: "gem_green_m", 5: "gem_pink_m", 6: "gem_yellow_m"]
     
-    private var worryUpdateList: [WorryListPublisherModel] = []
-    
-    private var cancellables = Set<AnyCancellable>()
-    
     typealias Input = AnyPublisher<Int, Never>
     typealias Output = AnyPublisher<[WorryListPublisherModel], Error>
     
-    private let output = PassthroughSubject<[WorryListPublisherModel], Error> ()
+    private let output: PassthroughSubject<[WorryListPublisherModel], Error> = .init()
     
-    func transform(input: Input) -> AnyPublisher<[WorryListPublisherModel], Error> {
-        input.sink{[weak self] templateId in
-            self?.getNetworkResponse(templateId)
-        }
-        .store(in: &cancellables)
-        
-        return output.eraseToAnyPublisher()
+    func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<[WorryListPublisherModel], Error> {
+        input
+            .flatMap { templateId in
+                self.getNetworkResponse(templateId: templateId)
+            }
+            .eraseToAnyPublisher()
     }
     
     // MARK: - Functions
-    private func convertIdtoWorryList(_ data: [Worry]) {
-        worryUpdateList = []
+    private func convertIdtoWorryList(_ data: [Worry]) -> [WorryListPublisherModel] {
+        var worryList: [WorryListPublisherModel] = []
         data.forEach {
             guard let imgName = IdtoImgDict[$0.templateId] else { return }
-            worryUpdateList.append(WorryListPublisherModel(worryId: $0.worryId, templateId: $0.templateId, title: $0.title, period: $0.period, image: UIImage(named: imgName) ?? UIImage() ))
+            worryList.append(WorryListPublisherModel(worryId: $0.worryId, templateId: $0.templateId, title: $0.title, period: $0.period, image: UIImage(named: imgName) ?? UIImage() ))
         }
-        self.output.send(worryUpdateList)
+        return worryList
     }
     
-    private func getNetworkResponse(_ templateId: Int) {
-        ArchiveAPI.shared.getArchiveWorryList(param: templateId) { result in
-            guard let result = result, let data = result.data else {
-                self.output.send(completion: .failure(NSError()))
-                return
+    private func getNetworkResponse(templateId: Int) -> AnyPublisher<[WorryListPublisherModel], Error> {
+        Future<[WorryListPublisherModel], Error> { promise in
+            ArchiveAPI.shared.getArchiveWorryList(param: templateId) { result in
+                switch result {
+                case .success(let response):
+                    if let data = response.data {
+                        let worryList = self.convertIdtoWorryList(data.worry)
+                        promise(.success(worryList))
+                    } else {
+                        promise(.failure(ErrorCase.appError))
+                    }
+                case .failure(let errorCase):
+                    promise(.failure(errorCase))
+                }
             }
-            self.convertIdtoWorryList(data.worry)
         }
+        .eraseToAnyPublisher()
     }
 }

--- a/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
+++ b/KAERA/KAERA/Scenes/Archive/ViewModel/WorryListViewModel.swift
@@ -17,8 +17,6 @@ final class WorryListViewModel: ViewModelType {
     typealias Input = AnyPublisher<Int, Never>
     typealias Output = AnyPublisher<[WorryListPublisherModel], Error>
     
-    private let output: PassthroughSubject<[WorryListPublisherModel], Error> = .init()
-    
     func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<[WorryListPublisherModel], Error> {
         input
             .flatMap { templateId in

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -245,6 +245,7 @@ final class HomeWorryDetailVC: BaseVC {
                 case .finished:
                     break
                 case .failure(let err as ErrorCase):
+                    self?.presentNetworkAlert()
                     self?.errorView.modifyType(errorType: err)
                     self?.errorView.isHidden = false
                 default:

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -165,7 +165,7 @@ final class HomeWorryDetailVC: BaseVC {
                                       + 10)
                 }
                 
-            }else {
+            } else {
                 worryDetailContentView.snp.updateConstraints {
                     $0.height.equalTo(tableContentHeight + reviewSpacing + restReviewViewHeight + defaultTextViewHeight)
                 }

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
@@ -15,7 +15,6 @@ final class HomeWorryDetailViewModel: ViewModelType {
     typealias Output = AnyPublisher<WorryDetailModel, Error>
     
     private let output: PassthroughSubject<WorryDetailModel, Error> = .init()
-    private var cancellables = Set<AnyCancellable>()
     
     var worryDetail: WorryDetailModel?
     
@@ -27,7 +26,6 @@ final class HomeWorryDetailViewModel: ViewModelType {
             }
             .eraseToAnyPublisher()
     }
-
 }
 
 // MARK: - Network


### PR DESCRIPTION
## 💪 작업한 내용
- 고민보관함에서 네트워크 및 인앱 에러 시에 뜰 에러뷰를 구현했습니다. 


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- HomeWorryDetailVC와 동일한 방식으로 구현하였습니다!
- ErrorCase 열거형을 통해 자체적으로 internetError와 appError를 나눠주었습니다. 
- 이후 ArchiveAPI와 WorryListViewModel에서 각 에러별 분기처리를 해준 뒤 promise로 감싸 ArchiveVC로 보내주었습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 네트워크 에러 | 인앱 에러 |
| --------- | ---------- |
| <img width="350" alt="스크린샷 2023-11-12 오후 3 58 18" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/ae42d6a5-cf87-4564-9d09-3571acafa7f5"> | <img width="350" alt="스크린샷 2023-11-12 오후 3 57 31" src="https://github.com/TeamHARA/KAERA_iOS/assets/45239582/4c57f921-477e-4807-95df-89b793b3e897"> |

## 🚨 관련 이슈
- Resolved: #198 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
