### PR TITLE
[Feat] 홈 에러뷰 추가 및 combine 구독 이슈 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -33,7 +33,6 @@ class ArchiveVC: BaseVC, RefreshListDelegate {
     private var worryListWithTemplate: [WorryListPublisherModel] = []
     
     private var errorView = ErrorView().then {
-        $0.backgroundColor = .kGray1
         $0.isHidden = true
     }
     

--- a/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
+++ b/KAERA/KAERA/Scenes/Archive/View/ArchiveVC.swift
@@ -106,6 +106,7 @@ class ArchiveVC: BaseVC, RefreshListDelegate {
         )
         output.receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
+                self?.stopLoadingAnimation()
                 switch completion {
                 case .finished:
                     break

--- a/KAERA/KAERA/Scenes/Components/ErrorView.swift
+++ b/KAERA/KAERA/Scenes/Components/ErrorView.swift
@@ -20,10 +20,18 @@ final class ErrorView: UIView {
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: .zero)
+        self.backgroundColor = .kGray1
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Function
+    func updateTopOffset(_ offset: CGFloat) {
+        errorImageView.snp.updateConstraints {
+            $0.top.equalToSuperview().offset(offset.adjustedH)
+        }
     }
     
     func modifyType(errorType: ErrorCase) {
@@ -72,7 +80,7 @@ final class ErrorView: UIView {
         }
     }
     
-    // MARK: - Function
+
     private func setLayout() {
         self.addSubviews([errorImageView, errorBtn])
         

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -58,6 +58,10 @@ final class HomeGemStoneVC: BaseVC {
     
     private let gemStoneEmptyView = GemStoneEmptyView(mainTitle: "아직 고민 보석이 없네요!", subTitle: "작성된 고민 원석을\n빛나는 보석으로 만들어주세요.")
         
+    private let errorView = ErrorView().then {
+        $0.isHidden = true
+    }
+    
     // MARK: - Initialization
     init(type: PageType = .digging) {
         super.init(nibName: nil, bundle: nil)
@@ -74,6 +78,7 @@ final class HomeGemStoneVC: BaseVC {
         dataBind()
         setGemStoneCV()
         setLayout()
+        setErrorRealoadAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -83,8 +88,6 @@ final class HomeGemStoneVC: BaseVC {
         }else if pageType == .dug {
             input.send(1)
         }
-        
-
     }
 
     // MARK: - Function
@@ -100,29 +103,35 @@ final class HomeGemStoneVC: BaseVC {
     
     private func dataBind() {
         let output = gemListViewModel.transform(
-            input: HomeGemListViewModel
-                .Input(input)
+            input: HomeGemListViewModel.Input(input)
         )
-        
         output.receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
+                self?.stopLoadingAnimation()
                 switch completion {
                 case .finished:
                     break
-                case .failure:
-                    self?.presentNetworkAlert()
+                case .failure(let err as ErrorCase):
+                    self?.errorView.modifyType(errorType: err)
+                    self?.errorView.errorImageView.snp.updateConstraints {
+                        $0.top.equalToSuperview().offset(100.adjustedH)
+                    }
+                    self?.errorView.isHidden = false
+                default:
+                    break
                 }
             }, receiveValue: { [weak self] list in
+                self?.stopLoadingAnimation()
                 if self?.pageType == .digging {
                     HomeGemStoneCount.shared.count = list.count
                 }
                 self?.updateUI(gemList: list)
+                self?.errorView.isHidden = true
             })
             .store(in: &cancellables)
     }
     
     private func updateUI(gemList: [HomePublisherModel]) {
-        self.stopLoadingAnimation()
         self.gemStoneList = gemList
         self.gemStoneCV.reloadData()
         checkWhichViewIsHidden()
@@ -165,6 +174,22 @@ final class HomeGemStoneVC: BaseVC {
         self.present(vc, animated: true)
         
         LaunchingWithPushMessage.shared.hasLaunchedWithPush = false
+    }
+    private func setErrorRealoadAction() {
+        self.errorView.pressBtn { [weak self] in
+            self?.reloadErrorView()
+        }
+    }
+    
+    private func reloadErrorView() {
+        cancellables = []
+        dataBind()
+        self.startLoadingAnimation()
+        if pageType == .digging {
+            input.send(0)
+        }else if pageType == .dug {
+            input.send(1)
+        }
     }
 }
 
@@ -225,7 +250,7 @@ extension HomeGemStoneVC: UICollectionViewDataSource {
 extension HomeGemStoneVC {
     private func setLayout() {
         self.view.backgroundColor = .kGray1
-        self.view.addSubviews([stoneEmptyView, gemStoneEmptyView, gemStoneCV])
+        self.view.addSubviews([stoneEmptyView, gemStoneEmptyView, gemStoneCV, errorView])
         
         gemStoneCV.snp.makeConstraints {
             $0.directionalHorizontalEdges.top.equalToSuperview()
@@ -243,5 +268,10 @@ extension HomeGemStoneVC {
             $0.directionalHorizontalEdges.equalToSuperview()
             $0.height.equalTo(185.adjustedH)
         }
+        
+        errorView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
     }
 }

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -112,6 +112,7 @@ final class HomeGemStoneVC: BaseVC {
                 case .finished:
                     break
                 case .failure(let err as ErrorCase):
+                    self?.presentNetworkAlert()
                     self?.errorView.modifyType(errorType: err)
                     self?.errorView.updateTopOffset(100)
                     self?.errorView.isHidden = false

--- a/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeGemStone/HomeGemStoneVC.swift
@@ -113,9 +113,7 @@ final class HomeGemStoneVC: BaseVC {
                     break
                 case .failure(let err as ErrorCase):
                     self?.errorView.modifyType(errorType: err)
-                    self?.errorView.errorImageView.snp.updateConstraints {
-                        $0.top.equalToSuperview().offset(100.adjustedH)
-                    }
+                    self?.errorView.updateTopOffset(100)
                     self?.errorView.isHidden = false
                 default:
                     break

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -239,7 +239,7 @@ final class HomeWorryDetailVC: BaseVC {
         )
         output.receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
-                self?.stopLoadingAnimation() /// 어떠한 요청이든 로딩 액션 중지
+                self?.stopLoadingAnimation()
                 switch completion {
                 case .finished:
                     break
@@ -251,15 +251,14 @@ final class HomeWorryDetailVC: BaseVC {
                     break
                 }
             }, receiveValue: { [weak self] worryDetail in
+                self?.stopLoadingAnimation()
                 self?.updateUI(worryDetail: worryDetail)
-                self?.errorView.isHidden = true /// 데이터 로드 성공, 에러 뷰 숨김
+                self?.errorView.isHidden = true
             })
             .store(in: &cancellables)
     }
     
     private func updateUI(worryDetail: WorryDetailModel) {
-        self.stopLoadingAnimation()
-        
         questions = worryDetail.subtitles
         answers = worryDetail.answers
         updateDate = worryDetail.updatedAt

--- a/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
+++ b/KAERA/KAERA/Scenes/Home/View/HomeWorryDetail/HomeWorryDetailVC.swift
@@ -55,7 +55,6 @@ final class HomeWorryDetailVC: BaseVC {
     }
     
     private var errorView = ErrorView().then {
-        $0.backgroundColor = .kGray1
         $0.isHidden = true
     }
 


### PR DESCRIPTION
## 💪 작업한 내용
- 홈화면에 에러뷰를 추가하고 에러뷰 관련 수정하였습니다.
  - 에러뷰 클래스 init에 backgroundColor를 gray로 지정하도록 수정하여 각` VC에서 따로 에러뷰의 backgroundColor 지정하는 코드 삭제`
  - 홈에서 에러뷰를 띄울때 이미 설정되어 있는 top Offset을 수정해야해서 해당 작업을 해주는 함수를 따로작성해서 홈에서 에러뷰 띄울때 호출
  
- 기존에 combine을 통해 VC와 VM간에 에러 핸들링 하는 과정에서 오류가 있던 부분을 Future, promise flatMap 등으로 임시 수정했었습니다. 그러나 기존 코드에서 구독 취소 로직만 따로 추가하는 것으로 오류를 수정할 수 있다는 것을 알게되어 재수정하였습니다.
  - 구독 취소는 VC,VM 각각 sink를 통해 구독한 구독을 cancellables에 저장했는데 이 cancellables를 초기화 시켜줌으로써 취소함
  - output으로 설정한 PassthroughSubject 퍼블리셔를 통해 failure를 전송하면 그 이후로 어떤값을 보내든 failure로 보내기 때문에 
   output에 PassthroughSubject 객체를 새로 할당
  
추가로 dataBind 메서드의 sink에서 receiveCompletion과 receiveValue 파라미터가 있는데 
VM의 output에서는 failure이 들어올때는 receiveValue가 호출 안되고 receiveCompletion 만 호출되고,
output에서 값을 보낼때는 그 반대이므로 로딩 애니메이션을 정지시켜주는 stopLoadingAnimation를 각각에 추가해줌

## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기존에 임시 수정했던 Future, promise를 썼을때 잘 되었던 것은 Future라는 퍼블리셔가 값을 한번만 보내고 바로 finished가 불리면서 구독이 끝나는 퍼블리셔이기 때문인데요. 그래서 기존에 PassthroughSubject처럼 따로 구독을 해지시켜주지 않아도 됩니다.

- 기존에 output 퍼블리셔를 PassthroughSubject로 썼을때 문제가 되었던 것은 failure를 스트림에서 내보내게 되면 그 이후로 어떤 값은 보내든 이 퍼블리셔를 sink하는 곳에서 receiveCompletion의 failure만 계속 호출되어 input에서 값을 보내어 API 호출해서 값을 정상적으로 보내더라도 receiveCompletion이 호출되어 문제가 되었던 것입니다. 

- 사실 Future를 이용한 방법도 충분히 괜찮은 에러 핸들링 방법이라고 방법이라고 생각되는데 기존의 input, output PassthroughSubject 퍼블리셔를 통해 에러 핸들링하는게 다른 비동기 로직과 일관성 있게 로직을 가져갈 수 있어서 기존 방법의 에러를 해결해 재수정하는 것으로 진행하였습니다.

### flatMap과 Future
- 추가로 Future, flatMap을 통해 에러를 해결을 했을때 사실 왜 이게 동작하는지 의문이 있었는데 이제 어느 정도 의문이 해결되어 간단하게 정리를 해보고자 합니다.

우선 구조자체는 VC에서 dataBind를 통해 VM의 transform 함수를 실행해서 인자로 넘긴 input 퍼블리셔를 flatMap을 이용해 다른 퍼블리셔와 결합시켜서 하나의 스트림으로 만들어주는데, 다른 퍼블리셔는 flatMap 클로저에서 API 통신 함수호출하고 Future를 새로 만들어 API 요청에 대한 결과를 받아 Promise 를 통해 결과에 따라 값을 보내고 그렇게 만든 Future를 AnyPublisher로 변환하여 리턴합니다.
결국 `input + AnyPublisher(Future)를 합쳐 하나의 스트림`을 만들어 output으로 리턴하면 `VC에서는 그 output을 sink를 통해 구독 `하는 것입니다.
이후 VC에서 input.send로 신호를 보내면 VM에서 flatMap의 API 함수 호출 -> Future 퍼블리셔 생성 -> API 요청 및 리스폰스를 Promise로 방출 -> output.sink 클로져 실행으로 진행됩니다.
만약 Promise를 통해 failure가 보내졌을 때 VC에서 dataBind를 다시 실행해 다시 새로운 스트림을 만들어 input ... output으로 비동기 데이터 전달을 다시 수행

```swift
    // MARK: - Function
    func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<WorryDetailModel, Error> {
        input
            .flatMap { worryId in
                self.getWorryDetail(worryId: worryId)
            }
            .eraseToAnyPublisher()
    }
}

// MARK: - Network
extension HomeWorryDetailViewModel {
    private func getWorryDetail(worryId: Int) -> AnyPublisher<WorryDetailModel, Error> {
        Future<WorryDetailModel, Error> { promise in
            HomeAPI.shared.getWorryDetail(param: worryId) { result in
                switch result {
                case .success(let response):
                    if let data = response.data {
                        promise(.success(data))
                        self.worryDetail = data
                    } else {
                        promise(.failure(ErrorCase.appError))
                    }
                case .failure(let errorCase):
                    promise(.failure(errorCase))
                }
            }
        }
        .eraseToAnyPublisher()
    }
}

```

그런데 이렇게 구조를 공부하면 들었던 몇가지 의문이 있는데
1. `Future는 한번 방출 하면 종료되는 퍼블리셔인데 Future가 값을 보낸 이후에도 output에서 finished가 호출이 되지 않고 input.send를 통해 값을 보내면 VC에서 추가적인 dataBind 없이도 정상적으로 input을 받아 output을 방출해줌`
  - 이건 Input과 flatMap으로 Future를 합친 복합적인 하나의 스트림으로 생성이 되기 때문에 Future이 값을 방출했지만 이 스트림에서 추가적으로 input의 값이 들어 올 수 있다고 보기 때문인것 같습니다. (from gpt선생) 그렇기 때문에 input.send(.finished)를 호출해주면 input을 통해 이 스트림은 끝났다는 신호를 받기 때문에 output에서 finished 호출이 됩니다.
  - 제가 생각했던것은 output 스트림이 Future 로 만들어진 스트림이라고 생각했는데, Future는 API호출을 통해 받은 결과를 처리하는 퍼블리셔일뿐 결국 VC에서 구독하는 output은 input과 Future가 flatMap으로 합쳐진 하나의 스트림이기 때문에 기본 Future 와 다르게 동작할 수 있는 것 같습니다.
  
2. `Future에서 failure가 보내졌을때 output 스트림은 죽게되지만 input쪽 스트림은 살아있기 때문에 input.send하면 flatMap의 API 함수는 실행되어야 한다고 생각했는데 아무것도 실행되지 않음`
  - 이부분은 input으로 값을 보내는 스트림과 output으로 값을 보내는 스트림이 아예 독립적이라고 생각했는데 그게 아니라 만약 Future에서 failure가 발생되면 그 값이 input.flatMap{ }으로 input과 스트립이 합쳐지는 쪽으로 들어오기 때문에 input.send로 값을 보내봤자 이미 스트림이 죽어서 아무것도 실행되지 않는 것 같습니다.(아래 그림 참고)
 
제가 이해한 구조인데 정확하지는 않겠지만 대충 이런 식으로 되어있는것 같습니다..
<img width="788" alt="image" src="https://github.com/TeamHARA/KAERA_iOS/assets/32871014/a4b43cd4-4b3d-4728-ac0e-0bcca1fea2e9">

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #197


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
