### PR TITLE
[Fix] 마이페이지 무한 로딩 이슈 수정

### DIFF
--- a/KAERA/KAERA/Scenes/Auth/ViewModel/MyPaggeViewModel.swift
+++ b/KAERA/KAERA/Scenes/Auth/ViewModel/MyPaggeViewModel.swift
@@ -51,10 +51,7 @@ final class MyPaggeViewModel: ViewModelType {
         UNUserNotificationCenter.current().getNotificationSettings { setting in
             PushSettingInfo.shared.isPushOn = setting.alertSetting == .enabled
             let hasChanged: Bool = priorState != PushSettingInfo.shared.isPushOn
-            ///  이전과 상태과 바뀌었으면 상태값 send
-            if hasChanged{
-                self.output.send(.push(hasChanged: hasChanged))
-            }
+            self.output.send(.push(hasChanged: hasChanged))
         }
     }
 

--- a/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
+++ b/KAERA/KAERA/Scenes/Home/ViewModel/HomeWorryDetailViewModel.swift
@@ -22,8 +22,8 @@ final class HomeWorryDetailViewModel: ViewModelType {
     // MARK: - Function
     func transform(input: AnyPublisher<Int, Never>) -> AnyPublisher<WorryDetailModel, Error> {
         input
-            .sink { worryId in
-                self.getWorryDetail(worryId: worryId)
+            .sink { [weak self] worryId in
+                self?.getWorryDetail(worryId: worryId)
             }
             .store(in: &cancellables)
         return output.eraseToAnyPublisher()


### PR DESCRIPTION
## 💪 작업한 내용
- 마이페이지에서 hasChanged가 true일때만(유저가 푸시 알림 상태를 변경했을때만) VC로 푸시알림 UI가 바뀌었다는 output을 전송함
- 이 때문에 푸시알림을 안 바꿨을때는 VC쪽으로 output이 안가서 로딩화면이 안멈춰지고 로직이 제대로 진행이 안되는 문제 발생하여
- if 문을 삭제하고 hasChanged가 true, false 일때 모두 hasChanged의 상태를 VC로 전달


## 🚨 관련 이슈
- Resolved: #201 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
